### PR TITLE
Fix pitch octave jumping on transport stop/restart

### DIFF
--- a/permute-device.js
+++ b/permute-device.js
@@ -761,7 +761,10 @@ TransposeStrategy.prototype.revertTranspose = function() {
     debug("transpose", "revertTranspose called, originalTranspose=" + this.originalTranspose);
     this.applyTranspose(false);
     debug("transpose", "revertTranspose complete");
-    this.originalTranspose = null;
+    // Do not reset originalTranspose here - it must persist across transport
+    // cycles to prevent octave jumping on stop/restart (issue #9).
+    // It is naturally reset when a new strategy instance is created via
+    // detectInstrumentType().
 };
 
 /**


### PR DESCRIPTION
Remove the clearing of originalTranspose in revertTranspose(). Setting it
to null caused the baseline transpose value to be lost between transport
cycles. On restart, applyTranspose would re-capture the current (possibly
already-shifted) parameter value as the new baseline, compounding the
offset on each cycle.

The originalTranspose value now persists for the lifetime of the strategy
object and is only reset when detectInstrumentType() creates a new
strategy instance.

Fixes #9

https://claude.ai/code/session_01RjG9mhoFbLMEHDqscLJ6dK