### PR TITLE
Implement robustness refactor: fix state persistence, add lifecycle, modularize

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,16 @@ Permute is a Max4Live device that provides mute sequencing, pitch sequencing, an
 
 | File | Purpose |
 |------|---------|
-| `permute-device.js` | Core JavaScript (~3000 lines) - all sequencer logic |
+| `permute-device.js` | Main device controller (~1740 lines) - init, transport, batching, state |
+| `permute-constants.js` | Constants, config, value types |
+| `permute-utils.js` | Debug, error handling, observer creation, tick calculation |
+| `permute-sequencer.js` | `Sequencer` class (pattern, timing, step progression) |
+| `permute-observer-registry.js` | `ObserverRegistry` class |
+| `permute-state.js` | `TrackState`, `ClipState`, `TransportState` |
+| `permute-instruments.js` | `InstrumentDetector`, transpose strategy classes |
+| `permute-commands.js` | `CommandRegistry` class |
+| `permute-shuffle.js` | Pure shuffle/swap functions for temperature |
+| `permute-temperature.js` | Temperature mixin (capture/restore/loop jump) |
 | `Permute.amxd` | Max4Live device file (load this in Ableton) |
 | `Permute.maxpat` | Max patch (UI and routing) |
 | `README.md` | User-facing documentation |

--- a/docs/adr/003-robust-state-restoration.md
+++ b/docs/adr/003-robust-state-restoration.md
@@ -1,0 +1,64 @@
+# ADR-003: Robust State Restoration & Initialization Lifecycle
+
+**Date:** 2026-02-13
+**Status:** Implemented
+
+## Context
+
+After ADR-002 fixed the argument count mismatch in `restoreState()`, a deeper problem remained: `restoreState()` bypassed all setter methods, writing directly to `.pattern[i]`, `.patternLength`, `.division`, and `.temperatureValue`. This left the device in a partially-initialized state where pattern data looked correct but sequencer infrastructure (transport observers, step timing, temperature activation) was never configured.
+
+Additionally, `init()` broadcast default state to pattr before restoration could run, creating a race condition that could overwrite saved state with defaults.
+
+### Root Causes
+
+1. **`restoreState()` bypassed setters** - Side effects like `checkAndActivateObservers()`, `calculateTicksPerStep()`, and temperature state management were never triggered on restore.
+
+2. **`init()` broadcast defaults to pattr** - `broadcastState('init')` output `pattr_state` with default patterns before `restoreState()` or `setvalueof()` could run.
+
+3. **Two restoration paths with divergent behavior** - `restoreState()` (flat 28-arg format) directly wrote properties, while `setvalueof()` (JSON format) correctly called `setState()` with proper setters.
+
+## Decision
+
+### 1. Rewrite `restoreState()` as thin adapter
+
+`restoreState()` now parses the flat 28-arg format into a JSON state object and delegates entirely to `setState()`, which uses proper setters (`setPattern()`, `setLength()`, `setDivision()`, `setTemperatureValue()`).
+
+This ensures:
+- Observer activation via `checkAndActivateObservers()` in `setPattern()`
+- Tick calculation via `calculateTicksPerStep()` in `setDivision()`
+- Temperature state capture/restore via `setTemperatureValue()`
+- Pattern validation in `setPattern()`
+
+### 2. Exclude `'init'` origin from pattr_state output
+
+Added `origin !== 'init'` to the pattr_state output guard in `broadcastState()`. This prevents `init()` from overwriting saved pattr data with defaults.
+
+### 3. Add `initialized` lifecycle flag
+
+Added `this.initialized = false` to the constructor, set to `true` at end of `init()`, `restoreState()`, and `setvalueof()`. The pattr_state output is guarded by this flag, preventing any state output during the init/restore window.
+
+### 4. Clean up debug logging
+
+Reduced verbose investigation logging in `getvalueof()` and `setvalueof()` to single-line debug summaries. Error logging preserved.
+
+## Consequences
+
+### Positive
+- State restores correctly with all side effects (observers, timing, temperature)
+- Single restoration implementation (`setState()`) regardless of entry point
+- No pattr feedback during initialization window
+- Clean console output (no investigation spam)
+
+### Negative
+- Temporary `[INIT-SEQUENCE]` logging added for empirical startup order documentation (to be removed after verification)
+
+## Files Changed
+
+| File | Changes |
+|------|---------|
+| `permute-device.js` | Rewrote `restoreState()` as adapter, added `initialized` flag, guarded pattr output, cleaned up logging |
+
+## Related
+
+- ADR-002: Restore State Format Fix (previous partial fix)
+- Issue #4: State not restoring properly when loading from saved Live Set

--- a/docs/adr/004-modularization.md
+++ b/docs/adr/004-modularization.md
@@ -1,0 +1,93 @@
+# ADR-004: Modularization into Focused Files
+
+**Date:** 2026-02-13
+**Status:** Implemented
+
+## Context
+
+`permute-device.js` was a ~3000-line monolith containing constants, utilities, six class definitions, pure functions, and the main device controller. This made it difficult to navigate, understand dependencies, and test individual components.
+
+Max's `v8` object supports `require()` with CommonJS modules, with the constraint that all required files must be in the same directory (flat structure).
+
+## Decision
+
+Extract logical units into separate CommonJS modules, all placed alongside `permute-device.js` (flat structure per Max constraint).
+
+### Module Structure
+
+| Module | Contents | Dependencies |
+|--------|----------|-------------|
+| `permute-constants.js` | Constants, config, value types | None |
+| `permute-utils.js` | Debug, error handling, observer creation, tick calculation | constants |
+| `permute-sequencer.js` | `Sequencer` class | constants, utils |
+| `permute-observer-registry.js` | `ObserverRegistry` class | None |
+| `permute-state.js` | `TrackState`, `ClipState`, `TransportState` | None |
+| `permute-instruments.js` | `InstrumentDetector`, strategy classes | constants, utils |
+| `permute-commands.js` | `CommandRegistry` class | None |
+| `permute-shuffle.js` | Pure shuffle/swap functions | constants, utils |
+| `permute-temperature.js` | Temperature mixin (`applyTemperatureMethods`) | constants, utils, shuffle |
+
+### Temperature Mixin Pattern
+
+Temperature methods operate on `SequencerDevice.prototype` but are logically separate. Used a mixin pattern:
+
+```javascript
+// permute-temperature.js
+function applyTemperatureMethods(proto) {
+    proto.setTemperatureValue = function(value) { ... };
+    proto.captureTemperatureState = function(clipId) { ... };
+    // ...
+}
+
+// permute-device.js (after SequencerDevice is defined)
+temperature.applyTemperatureMethods(SequencerDevice.prototype);
+```
+
+### Consolidated Pitch Offset Helper
+
+The duplicated pitch offset calculation in `captureTemperatureState()`, `restoreTemperatureState()`, and `onTemperatureLoopJump()` was consolidated into `_getCurrentPitchOffset(clipId)`.
+
+### Renamed `lastAppliedValue` to `lastParameterValue`
+
+Clarified the distinction between `Sequencer.lastParameterValue` (clip-independent, for parameter-based transpose) and `SequencerDevice.lastValues[clipId]` (per-clip, for note-based operations).
+
+### What Stays in Main File
+
+- `require()` imports
+- `autowatch`, `inlets`, `outlets`
+- `SequencerDevice` constructor and core methods
+- All global Max message handler functions (must be in main file for `v8` exposure)
+- Global instance: `var sequencer = new SequencerDevice()`
+
+## Consequences
+
+### Positive
+- `permute-device.js` reduced from ~3000 to ~1740 lines
+- Pitch offset calculation in exactly one place (`_getCurrentPitchOffset`)
+- Clear dependency graph between modules
+- Shuffle functions independently testable (pure, no device coupling)
+- Easier to locate and understand code sections
+
+### Negative
+- `autowatch = 1` won't detect changes in required modules (acceptable for production)
+- Slight overhead from `require()` calls (negligible, runs once on load)
+
+## Files Changed
+
+| File | Changes |
+|------|---------|
+| `permute-device.js` | Added requires, removed extracted code, applied temperature mixin, renamed `lastAppliedValue` |
+| `permute-constants.js` | New: constants, config, value types |
+| `permute-utils.js` | New: utilities |
+| `permute-sequencer.js` | New: Sequencer class |
+| `permute-observer-registry.js` | New: ObserverRegistry |
+| `permute-state.js` | New: TrackState, ClipState, TransportState |
+| `permute-instruments.js` | New: InstrumentDetector, strategies |
+| `permute-commands.js` | New: CommandRegistry |
+| `permute-shuffle.js` | New: pure shuffle functions |
+| `permute-temperature.js` | New: temperature mixin with `_getCurrentPitchOffset` |
+
+## Related
+
+- ADR-003: Robust State Restoration (prerequisite)
+- Max `v8` module documentation

--- a/permute-commands.js
+++ b/permute-commands.js
@@ -1,0 +1,41 @@
+/**
+ * permute-commands.js - Command registry for message dispatch
+ *
+ * Maps message types to handler functions, replacing large switch statements.
+ */
+
+/**
+ * CommandRegistry - Maps message types to handler functions.
+ * Replaces large switch statements with cleaner dispatch pattern.
+ */
+function CommandRegistry() {
+    this.commands = {};
+}
+
+/**
+ * Register a command handler.
+ * @param {string} command - Command name
+ * @param {Function} handler - Handler function
+ */
+CommandRegistry.prototype.register = function(command, handler) {
+    this.commands[command] = handler;
+};
+
+/**
+ * Execute a command.
+ * @param {string} command - Command name
+ * @param {Array} args - Command arguments
+ * @param {Object} context - Context object (usually 'this')
+ * @returns {boolean} - True if command was handled
+ */
+CommandRegistry.prototype.execute = function(command, args, context) {
+    if (this.commands[command]) {
+        this.commands[command].call(context, args);
+        return true;
+    }
+    return false;
+};
+
+module.exports = {
+    CommandRegistry: CommandRegistry
+};

--- a/permute-constants.js
+++ b/permute-constants.js
@@ -1,0 +1,83 @@
+/**
+ * permute-constants.js - Constants, configuration, and value types
+ *
+ * Shared constants used across all Permute modules.
+ *
+ * @requires Max4Live JavaScript API
+ */
+
+// ===== Configuration =====
+// Transpose configuration for pitch sequencer
+var TRANSPOSE_CONFIG = {
+    parameterNames: [
+        { name: "custom e", shiftAmount: 21 },
+        { name: "pitch", shiftAmount: 16 },
+        { name: "transpose", shiftAmount: 16 },
+        { name: "octave", shiftAmount: 16 }
+    ],
+    defaultShiftAmount: 12
+};
+
+// ===== CONSTANTS =====
+var TICKS_PER_QUARTER_NOTE = 480;
+var MIDI_MIN = 0;
+var MIDI_MAX = 127;
+var OCTAVE_SEMITONES = 12;
+var DEFAULT_TIME_SIGNATURE = 4;
+var MAX_PATTERN_LENGTH = 64;
+var MIN_PATTERN_LENGTH = 1;
+var DEFAULT_GAIN_VALUE = 1.0;
+var MUTED_GAIN = 0.0;
+var DEFAULT_DRUM_RACK_TRANSPOSE = 64;
+var INVALID_LIVE_API_ID = "0";
+var TASK_SCHEDULE_DELAY = 1;
+
+// ===== VALUE TYPES =====
+
+/**
+ * Value type definitions for different sequencer types.
+ * Each type defines validation, default value, and range.
+ */
+var VALUE_TYPES = {
+    binary: {
+        validate: function(v) { return v === 0 || v === 1; },
+        default: 0,
+        range: [0, 1],
+        description: "On/Off (0 or 1)"
+    },
+    midi_range: {
+        validate: function(v) { return v >= MIDI_MIN && v <= MIDI_MAX; },
+        default: 64,
+        range: [MIDI_MIN, MIDI_MAX],
+        description: "MIDI value (0-127)"
+    },
+    normalized: {
+        validate: function(v) { return v >= 0.0 && v <= 1.0; },
+        default: 0.5,
+        range: [0.0, 1.0],
+        description: "Normalized (0.0-1.0)"
+    },
+    semitones: {
+        validate: function(v) { return v >= -48 && v <= 48; },
+        default: 0,
+        range: [-48, 48],
+        description: "Semitones (-48 to +48)"
+    }
+};
+
+module.exports = {
+    TRANSPOSE_CONFIG: TRANSPOSE_CONFIG,
+    TICKS_PER_QUARTER_NOTE: TICKS_PER_QUARTER_NOTE,
+    MIDI_MIN: MIDI_MIN,
+    MIDI_MAX: MIDI_MAX,
+    OCTAVE_SEMITONES: OCTAVE_SEMITONES,
+    DEFAULT_TIME_SIGNATURE: DEFAULT_TIME_SIGNATURE,
+    MAX_PATTERN_LENGTH: MAX_PATTERN_LENGTH,
+    MIN_PATTERN_LENGTH: MIN_PATTERN_LENGTH,
+    DEFAULT_GAIN_VALUE: DEFAULT_GAIN_VALUE,
+    MUTED_GAIN: MUTED_GAIN,
+    DEFAULT_DRUM_RACK_TRANSPOSE: DEFAULT_DRUM_RACK_TRANSPOSE,
+    INVALID_LIVE_API_ID: INVALID_LIVE_API_ID,
+    TASK_SCHEDULE_DELAY: TASK_SCHEDULE_DELAY,
+    VALUE_TYPES: VALUE_TYPES
+};

--- a/permute-instruments.js
+++ b/permute-instruments.js
@@ -1,0 +1,176 @@
+/**
+ * permute-instruments.js - Instrument detection and transpose strategies
+ *
+ * Handles finding instrument devices on tracks and applying pitch transposition
+ * via device parameters.
+ *
+ * @requires permute-constants
+ * @requires permute-utils
+ */
+
+var constants = require('permute-constants');
+var INVALID_LIVE_API_ID = constants.INVALID_LIVE_API_ID;
+var DEFAULT_DRUM_RACK_TRANSPOSE = constants.DEFAULT_DRUM_RACK_TRANSPOSE;
+var MIDI_MIN = constants.MIDI_MIN;
+var MIDI_MAX = constants.MIDI_MAX;
+
+var utils = require('permute-utils');
+var debug = utils.debug;
+var handleError = utils.handleError;
+
+// ===== INSTRUMENT DETECTOR HELPER =====
+
+/**
+ * InstrumentDetector - Shared helper for finding instrument devices.
+ * V4.0: Simplified to just find the device, not classify it.
+ */
+function InstrumentDetector() {}
+
+/**
+ * Find the first instrument device on a track.
+ * V4.0: No longer classifies device type - just finds it.
+ *
+ * @param {LiveAPI} track - Track to analyze
+ * @returns {Object|null} - { device, deviceId } or null
+ */
+InstrumentDetector.findInstrumentDevice = function(track) {
+    if (!track) return null;
+
+    try {
+        var devices = track.get("devices");
+        if (!devices || devices.length === 0) return null;
+
+        for (var i = 0; i < devices.length; i++) {
+            var devicePath = track.path + " devices " + i;
+            var device = new LiveAPI(devicePath);
+
+            if (!device || device.id === INVALID_LIVE_API_ID) continue;
+
+            var deviceType = device.get("type");
+            var isInstrument = (deviceType && (deviceType[0] === "instrument" || deviceType[0] === 1));
+
+            if (isInstrument) {
+                return {
+                    device: device,
+                    deviceId: device.id
+                };
+            }
+        }
+    } catch (err) {
+        handleError("InstrumentDetector.findInstrumentDevice", err, false);
+    }
+
+    return null;
+};
+
+// ===== INSTRUMENT STRATEGY PATTERN =====
+
+/**
+ * InstrumentStrategy - Base class for instrument-specific pitch handling.
+ */
+function InstrumentStrategy(device) {
+    this.device = device;
+    this.originalTranspose = null;
+}
+
+InstrumentStrategy.prototype.applyTranspose = function(value) {
+    // Override in subclasses
+};
+
+InstrumentStrategy.prototype.revertTranspose = function() {
+    // Override in subclasses
+};
+
+/**
+ * TransposeStrategy - Unified parameter-based pitch transposition.
+ * V4.0: Single strategy for all devices with named transpose parameters.
+ * Works for drum racks, instrument racks, and any device with a transpose macro.
+ *
+ * @param {LiveAPI} device - Device containing the transpose parameter
+ * @param {LiveAPI} transposeParam - The transpose parameter API object
+ * @param {number} shiftAmount - Amount to shift for octave (16 or 21)
+ * @param {string} paramName - Name of the parameter (for debugging)
+ */
+function TransposeStrategy(device, transposeParam, shiftAmount, paramName) {
+    InstrumentStrategy.call(this, device);
+    this.transposeParam = transposeParam;
+    this.shiftAmount = shiftAmount;
+    this.paramName = paramName;
+}
+TransposeStrategy.prototype = Object.create(InstrumentStrategy.prototype);
+TransposeStrategy.prototype.constructor = TransposeStrategy;
+
+TransposeStrategy.prototype.applyTranspose = function(shouldShiftUp) {
+    debug("transpose", "applyTranspose(" + shouldShiftUp + ") called, originalTranspose=" + this.originalTranspose);
+
+    if (!this.device || !this.transposeParam) {
+        debug("transpose", "applyTranspose BAIL: missing device or param");
+        return;
+    }
+
+    try {
+        if (this.transposeParam.id === INVALID_LIVE_API_ID) {
+            debug("transpose", "applyTranspose BAIL: param id invalid");
+            return;
+        }
+
+        var currentTranspose = this.transposeParam.get("value");
+        var currentValue = currentTranspose ? currentTranspose[0] : DEFAULT_DRUM_RACK_TRANSPOSE;
+        debug("transpose", "currentValue from param: " + currentValue);
+
+        if (this.originalTranspose === null) {
+            this.originalTranspose = currentValue;
+            debug("transpose", "captured originalTranspose=" + currentValue);
+        }
+
+        var newValue;
+        if (shouldShiftUp) {
+            newValue = this.originalTranspose + this.shiftAmount;
+        } else {
+            newValue = this.originalTranspose;
+        }
+
+        newValue = Math.max(MIDI_MIN, Math.min(MIDI_MAX, newValue));
+        debug("transpose", "setting param to " + newValue + " (original=" + this.originalTranspose + ", shift=" + this.shiftAmount + ")");
+        this.transposeParam.set("value", newValue);
+
+        debug("transpose", "Applied " + (shouldShiftUp ? "+" : "") +
+              this.shiftAmount + " via '" + this.paramName + "' param");
+    } catch (err) {
+        handleError("TransposeStrategy.applyTranspose", err, false);
+    }
+};
+
+TransposeStrategy.prototype.revertTranspose = function() {
+    debug("transpose", "revertTranspose called, originalTranspose=" + this.originalTranspose);
+    this.applyTranspose(false);
+    debug("transpose", "revertTranspose complete");
+    // Do not reset originalTranspose here - it must persist across transport
+    // cycles to prevent octave jumping on stop/restart (issue #9).
+    // It is naturally reset when a new strategy instance is created via
+    // detectInstrumentType().
+};
+
+/**
+ * DefaultInstrumentStrategy - Default (no device-based transpose).
+ */
+function DefaultInstrumentStrategy() {
+    InstrumentStrategy.call(this, null);
+}
+DefaultInstrumentStrategy.prototype = Object.create(InstrumentStrategy.prototype);
+DefaultInstrumentStrategy.prototype.constructor = DefaultInstrumentStrategy;
+
+DefaultInstrumentStrategy.prototype.applyTranspose = function(value) {
+    // No-op for default instruments
+};
+
+DefaultInstrumentStrategy.prototype.revertTranspose = function() {
+    // No-op for default instruments
+};
+
+module.exports = {
+    InstrumentDetector: InstrumentDetector,
+    InstrumentStrategy: InstrumentStrategy,
+    TransposeStrategy: TransposeStrategy,
+    DefaultInstrumentStrategy: DefaultInstrumentStrategy
+};

--- a/permute-observer-registry.js
+++ b/permute-observer-registry.js
@@ -1,0 +1,61 @@
+/**
+ * permute-observer-registry.js - Centralized observer management
+ *
+ * Tracks all active LiveAPI observers and guarantees cleanup on error/destruction.
+ */
+
+/**
+ * ObserverRegistry - Centralized observer management.
+ * Tracks all active observers and guarantees cleanup on error/destruction.
+ */
+function ObserverRegistry() {
+    this.observers = {}; // name -> observer
+}
+
+/**
+ * Register an observer.
+ * @param {string} name - Unique name for this observer
+ * @param {LiveAPI} observer - Observer object
+ */
+ObserverRegistry.prototype.register = function(name, observer) {
+    if (this.observers[name]) {
+        this.unregister(name);
+    }
+    this.observers[name] = observer;
+};
+
+/**
+ * Unregister an observer by name.
+ * @param {string} name - Observer name
+ */
+ObserverRegistry.prototype.unregister = function(name) {
+    if (this.observers[name]) {
+        this.observers[name].property = "";
+        delete this.observers[name];
+    }
+};
+
+/**
+ * Clear all observers.
+ */
+ObserverRegistry.prototype.clearAll = function() {
+    for (var name in this.observers) {
+        if (this.observers.hasOwnProperty(name)) {
+            this.observers[name].property = "";
+        }
+    }
+    this.observers = {};
+};
+
+/**
+ * Get observer by name.
+ * @param {string} name - Observer name
+ * @returns {LiveAPI|null} - Observer or null
+ */
+ObserverRegistry.prototype.get = function(name) {
+    return this.observers[name] || null;
+};
+
+module.exports = {
+    ObserverRegistry: ObserverRegistry
+};

--- a/permute-sequencer.js
+++ b/permute-sequencer.js
@@ -1,0 +1,197 @@
+/**
+ * permute-sequencer.js - Generic sequencer class
+ *
+ * Manages pattern, timing, and step progression for mute/pitch sequencing.
+ *
+ * @requires permute-constants
+ */
+
+var constants = require('permute-constants');
+var VALUE_TYPES = constants.VALUE_TYPES;
+var MAX_PATTERN_LENGTH = constants.MAX_PATTERN_LENGTH;
+var MIN_PATTERN_LENGTH = constants.MIN_PATTERN_LENGTH;
+
+// Import calculateTicksPerStep from utils
+var utils = require('permute-utils');
+var calculateTicksPerStep = utils.calculateTicksPerStep;
+var debug = utils.debug;
+
+/**
+ * Generic sequencer that manages pattern, timing, and step progression.
+ * Wraps a Transformation and adds step-based control.
+ *
+ * @param {string} name - Sequencer name (e.g., 'mute', 'pitch', 'velocity')
+ * @param {Transformation} transformation - The transformation this sequencer controls
+ * @param {string} valueType - Value type key from VALUE_TYPES
+ * @param {number} patternLength - Initial pattern length (default 8)
+ */
+function Sequencer(name, transformation, valueType, patternLength) {
+    this.name = name;
+    this.transformation = transformation;
+    this.valueType = VALUE_TYPES[valueType] || VALUE_TYPES.binary;
+    this.patternLength = patternLength || 8;
+
+    // Initialize pattern with default values
+    this.pattern = [];
+    for (var i = 0; i < this.patternLength; i++) {
+        this.pattern.push(this.valueType.default);
+    }
+
+    // State
+    this.currentStep = -1;
+    this.lastState = null;
+
+    // Default value for this sequencer (used by isActive)
+    // Mute defaults to 1 (unmuted), pitch defaults to 0 (no shift)
+    this.defaultValue = this.valueType.default;
+
+    // Timing
+    this.division = [1, 0, 0]; // Default 1 bar per step
+    this.ticksPerStep = 1920;
+
+    // Cache
+    this.cacheValid = false;
+
+    // Reference to device (set by SequencerDevice)
+    this.device = null;
+
+    // Tracks last value applied via parameter-based transpose (clip-independent).
+    // Distinct from SequencerDevice.lastValues[clipId] which tracks per-clip note-based state.
+    this.lastParameterValue = undefined;
+}
+
+/**
+ * Set pattern with validation.
+ * V6.0: Triggers lazy observer activation if pattern becomes active.
+ * @param {Array} pattern - New pattern values
+ */
+Sequencer.prototype.setPattern = function(pattern) {
+    var validated = [];
+    for (var i = 0; i < pattern.length; i++) {
+        var value = pattern[i];
+        if (this.valueType.validate(value)) {
+            validated.push(value);
+        } else {
+            validated.push(this.valueType.default);
+            debug("sequencer", "Invalid value " + value + " for " + this.name + ", using default");
+        }
+    }
+    this.pattern = validated;
+    this.patternLength = validated.length;
+
+    // V6.0: Check if we need to activate playback observers
+    if (this.device && this.device.checkAndActivateObservers) {
+        this.device.checkAndActivateObservers();
+    }
+};
+
+/**
+ * Set individual step value.
+ * V6.0: Triggers lazy observer activation if pattern becomes active.
+ * @param {number} index - Step index
+ * @param {*} value - Step value
+ */
+Sequencer.prototype.setStep = function(index, value) {
+    if (index >= 0 && index < this.pattern.length) {
+        if (this.valueType.validate(value)) {
+            this.pattern[index] = value;
+
+            // V6.0: Check if we need to activate playback observers
+            if (this.device && this.device.checkAndActivateObservers) {
+                this.device.checkAndActivateObservers();
+            }
+        } else {
+            debug("sequencer", "Invalid value " + value + " for step " + index);
+        }
+    }
+};
+
+/**
+ * Set pattern length, preserving existing values.
+ * @param {number} length - New pattern length (1-64)
+ */
+Sequencer.prototype.setLength = function(length) {
+    var newLength = Math.max(MIN_PATTERN_LENGTH, Math.min(MAX_PATTERN_LENGTH, length));
+
+    // Preserve existing values, fill new slots with defaults
+    while (this.pattern.length < newLength) {
+        this.pattern.push(this.valueType.default);
+    }
+
+    // Truncate if needed
+    if (this.pattern.length > newLength) {
+        this.pattern = this.pattern.slice(0, newLength);
+    }
+
+    this.patternLength = newLength;
+
+    // Reset step if out of bounds
+    if (this.currentStep >= newLength) {
+        this.currentStep = 0;
+    }
+};
+
+/**
+ * Set division timing.
+ * @param {Array|string} division - Division in [bars, beats, ticks] or legacy string format
+ * @param {number} timeSignature - Time signature numerator (for tick calculation)
+ */
+Sequencer.prototype.setDivision = function(division, timeSignature) {
+    this.division = division;
+    this.ticksPerStep = calculateTicksPerStep(division, timeSignature);
+};
+
+/**
+ * Calculate current step based on tick position.
+ * @param {number} ticks - Absolute tick position
+ * @returns {number} - Current step number
+ */
+Sequencer.prototype.calculateStep = function(ticks) {
+    return Math.floor(ticks / this.ticksPerStep) % this.patternLength;
+};
+
+/**
+ * Get current pattern value.
+ * @returns {*} - Value at current step
+ */
+Sequencer.prototype.getCurrentValue = function() {
+    if (this.currentStep >= 0 && this.currentStep < this.pattern.length) {
+        return this.pattern[this.currentStep];
+    }
+    return this.valueType.default;
+};
+
+/**
+ * Reset sequencer to initial state.
+ */
+Sequencer.prototype.reset = function() {
+    this.currentStep = -1;
+    this.lastState = null;
+};
+
+/**
+ * Check if sequencer is active (has non-default pattern values).
+ * Replaces explicit 'enabled' flag with pattern-derived state.
+ * - Mute: active if any step is 0 (muted)
+ * - Pitch: active if any step is 1 (shifted)
+ * @returns {boolean} - True if sequencer has active pattern
+ */
+Sequencer.prototype.isActive = function() {
+    for (var i = 0; i < this.patternLength; i++) {
+        if (this.pattern[i] !== this.defaultValue) {
+            return true;
+        }
+    }
+    return false;
+};
+
+/**
+ * Invalidate cache.
+ */
+Sequencer.prototype.invalidateCache = function() {
+    this.cacheValid = false;
+};
+
+module.exports = {
+    Sequencer: Sequencer
+};

--- a/permute-shuffle.js
+++ b/permute-shuffle.js
@@ -1,0 +1,174 @@
+/**
+ * permute-shuffle.js - Pure shuffle/swap functions for temperature transformation
+ *
+ * Contains Fisher-Yates shuffle, swap pattern generation, and application.
+ * These are pure functions with no device coupling, making them independently testable.
+ *
+ * @requires permute-constants
+ */
+
+var constants = require('permute-constants');
+
+// Import debug from utils for logging
+var utils = require('permute-utils');
+var debug = utils.debug;
+
+/**
+ * Fisher-Yates shuffle algorithm.
+ * Used by temperature transformation for random pitch swapping.
+ *
+ * @param {Array} array - Array to shuffle
+ * @returns {Array} - Shuffled copy
+ */
+function fisherYatesShuffle(array) {
+    var shuffled = array.slice();
+    for (var i = shuffled.length - 1; i > 0; i--) {
+        var j = Math.floor(Math.random() * (i + 1));
+        var temp = shuffled[i];
+        shuffled[i] = shuffled[j];
+        shuffled[j] = temp;
+    }
+    return shuffled;
+}
+
+/**
+ * Generate swap pattern for temperature transformation.
+ * Creates shuffle groups based on temperature value (0.0-1.0).
+ *
+ * Temperature ranges:
+ *   0.0-0.33: Pairs only (2 notes)
+ *   0.34-0.66: Mix of pairs and triplets (2-3 notes)
+ *   0.67-1.0: Larger groups (2-5 notes)
+ *
+ * @param {Array} notes - Array of note objects with start_time and pitch
+ * @param {number} temperature - Temperature value (0.0-1.0)
+ * @returns {Array} - Array of shuffle groups {indices: [...], shuffled: [...]}
+ */
+function generateSwapPattern(notes, temperature) {
+    if (!notes || notes.length < 2) {
+        return [];
+    }
+
+    // Create array of indices and sort by start_time (temporal adjacency)
+    var sortedIndices = [];
+    for (var i = 0; i < notes.length; i++) {
+        sortedIndices.push({
+            originalIndex: i,
+            startTime: notes[i].start_time,
+            pitch: notes[i].pitch
+        });
+    }
+
+    sortedIndices.sort(function(a, b) {
+        return a.startTime - b.startTime;
+    });
+
+    // Create non-overlapping shuffle groups
+    var groups = [];
+    var used = [];
+    for (var i = 0; i < sortedIndices.length; i++) {
+        used.push(false);
+    }
+
+    // V3.1: Track if we've created at least one group
+    var hasCreatedGroup = false;
+
+    for (var i = 0; i < sortedIndices.length; i++) {
+        if (used[i]) continue;
+
+        // Should we form a group starting here?
+        var roll = Math.random();
+
+        // V3.1: Guarantee at least one swap when temp > 0
+        // On last available pair, force creation if no groups yet
+        var isLastChance = !hasCreatedGroup && (i >= sortedIndices.length - 2);
+        var shouldFormGroup = (roll < temperature) || isLastChance;
+
+        if (!shouldFormGroup) {
+            continue;
+        }
+
+        // Determine group size based on temperature
+        var desiredSize;
+        if (temperature < 0.34) {
+            desiredSize = 2;
+        } else if (temperature < 0.67) {
+            desiredSize = Math.random() < 0.6 ? 2 : 3;
+        } else {
+            var sizes = [2, 3, 4, 5];
+            var weights = [0.2, 0.3, 0.3, 0.2];
+            var roll2 = Math.random();
+            var cumulative = 0;
+            desiredSize = 3;
+            for (var k = 0; k < sizes.length; k++) {
+                cumulative += weights[k];
+                if (roll2 < cumulative) {
+                    desiredSize = sizes[k];
+                    break;
+                }
+            }
+        }
+
+        // Collect adjacent unused notes
+        var group = [];
+        for (var j = i; j < Math.min(i + desiredSize, sortedIndices.length); j++) {
+            if (!used[j]) {
+                group.push(sortedIndices[j].originalIndex);
+                used[j] = true;
+            }
+            if (group.length >= desiredSize) break;
+        }
+
+        // Need at least 2 notes to shuffle
+        if (group.length >= 2) {
+            var shuffledIndices = fisherYatesShuffle(group);
+            groups.push({
+                indices: group,
+                shuffled: shuffledIndices
+            });
+            hasCreatedGroup = true;  // V3.1: Mark that we've created a group
+        }
+    }
+
+    debug("temperature", "Generated " + groups.length + " shuffle groups (guaranteed min 1 when temp > 0)");
+    return groups;
+}
+
+/**
+ * Apply swap pattern to notes.
+ * Swaps pitches according to the shuffle groups.
+ *
+ * @param {Array} notes - Array of note objects (will be modified in place)
+ * @param {Array} swapPattern - Array of shuffle groups from generateSwapPattern
+ */
+function applySwapPattern(notes, swapPattern) {
+    if (!notes || !swapPattern || swapPattern.length === 0) return;
+
+    // Capture current pitches
+    var currentPitches = [];
+    for (var i = 0; i < notes.length; i++) {
+        currentPitches.push(notes[i].pitch);
+    }
+
+    // Apply swaps
+    for (var i = 0; i < swapPattern.length; i++) {
+        var group = swapPattern[i];
+        for (var j = 0; j < group.indices.length; j++) {
+            var targetIdx = group.indices[j];
+            var sourceIdx = group.shuffled[j];
+
+            if (targetIdx < notes.length && sourceIdx < currentPitches.length) {
+                notes[targetIdx].pitch = currentPitches[sourceIdx];
+            } else {
+                debug("applySwapPattern", "Invalid index: targetIdx=" + targetIdx +
+                      ", sourceIdx=" + sourceIdx + ", noteCount=" + notes.length);
+            }
+        }
+    }
+}
+
+module.exports = {
+    fisherYatesShuffle: fisherYatesShuffle,
+    generateSwapPattern: generateSwapPattern,
+    applySwapPattern: applySwapPattern
+};

--- a/permute-state.js
+++ b/permute-state.js
@@ -1,0 +1,95 @@
+/**
+ * permute-state.js - State management objects
+ *
+ * Encapsulates track, clip, and transport state for the sequencer device.
+ */
+
+/**
+ * TrackState - Encapsulates track-related state.
+ */
+function TrackState() {
+    this.ref = null;       // LiveAPI track reference
+    this.id = null;        // Track ID
+    this.type = 'unknown'; // 'midi', 'audio', or 'unknown'
+    this.index = -1;       // Track index in session (for multi-track sequencer display)
+}
+
+TrackState.prototype.update = function(track) {
+    this.ref = track;
+    this.id = track ? track.id : null;
+    if (track) {
+        var hasMidiInput = track.get("has_midi_input");
+        var hasAudioInput = track.get("has_audio_input");
+        if (hasMidiInput && hasMidiInput[0] === 1) {
+            this.type = 'midi';
+        } else if (hasAudioInput && hasAudioInput[0] === 1) {
+            this.type = 'audio';
+        } else {
+            this.type = 'unknown';
+        }
+    } else {
+        this.type = 'unknown';
+    }
+};
+
+TrackState.prototype.reset = function() {
+    this.ref = null;
+    this.id = null;
+    this.type = 'unknown';
+    this.index = -1;
+};
+
+/**
+ * Extract track index from LiveAPI path.
+ * Path format: "live_set tracks N" or similar
+ * @param {string} path - LiveAPI path string
+ * @returns {number} - Track index or -1 if not found
+ */
+TrackState.prototype.extractIndexFromPath = function(path) {
+    if (!path) return -1;
+    var match = path.match(/tracks\s+(\d+)/);
+    if (match && match[1]) {
+        return parseInt(match[1], 10);
+    }
+    return -1;
+};
+
+/**
+ * ClipState - Encapsulates clip-related state.
+ */
+function ClipState() {
+    this.currentId = null;
+}
+
+ClipState.prototype.update = function(clipId) {
+    this.currentId = clipId;
+};
+
+ClipState.prototype.hasChanged = function(clipId) {
+    return this.currentId !== clipId;
+};
+
+ClipState.prototype.reset = function() {
+    this.currentId = null;
+};
+
+/**
+ * TransportState - Encapsulates transport-related state.
+ */
+function TransportState() {
+    this.isPlaying = false;
+}
+
+TransportState.prototype.setPlaying = function(playing) {
+    this.isPlaying = playing;
+};
+
+TransportState.prototype.reset = function() {
+    this.isPlaying = false;
+};
+
+module.exports = {
+    TrackState: TrackState,
+    ClipState: ClipState,
+    TransportState: TransportState
+};

--- a/permute-temperature.js
+++ b/permute-temperature.js
@@ -1,0 +1,321 @@
+/**
+ * permute-temperature.js - Temperature transformation mixin
+ *
+ * Temperature methods that are applied to SequencerDevice.prototype.
+ * Uses a mixin pattern since these methods operate on the device instance.
+ *
+ * @requires permute-constants
+ * @requires permute-utils
+ * @requires permute-shuffle
+ */
+
+var constants = require('permute-constants');
+var OCTAVE_SEMITONES = constants.OCTAVE_SEMITONES;
+
+var utils = require('permute-utils');
+var debug = utils.debug;
+var handleError = utils.handleError;
+var parseNotesResponse = utils.parseNotesResponse;
+var createObserver = utils.createObserver;
+var defer = utils.defer;
+
+var shuffle = require('permute-shuffle');
+var generateSwapPattern = shuffle.generateSwapPattern;
+var applySwapPattern = shuffle.applySwapPattern;
+
+/**
+ * Apply temperature methods to a prototype (mixin pattern).
+ * @param {Object} proto - The prototype to extend (SequencerDevice.prototype)
+ */
+function applyTemperatureMethods(proto) {
+
+    /**
+     * Get the current pitch offset for a clip based on pitch sequencer state.
+     * Consolidates the duplicated pitch offset calculation used in capture, restore,
+     * and loop jump operations.
+     *
+     * Returns OCTAVE_SEMITONES if pitch sequencer is currently shifting notes and
+     * using note-based transpose (not parameter-based). Returns 0 otherwise.
+     *
+     * @param {string} clipId - Clip ID to check
+     * @returns {number} - Pitch offset (0 or OCTAVE_SEMITONES)
+     */
+    proto._getCurrentPitchOffset = function(clipId) {
+        if (this.lastValues[clipId] && this.lastValues[clipId].pitch === 1
+            && this.instrumentType !== 'parameter_transpose') {
+            return OCTAVE_SEMITONES;
+        }
+        return 0;
+    };
+
+    /**
+     * Setup temperature loop_jump observer.
+     * Regenerates swap pattern on each loop.
+     */
+    proto.setupTemperatureLoopJumpObserver = function() {
+        this.clearTemperatureLoopJumpObserver();
+
+        var clip = this.getCurrentClip();
+        if (!clip) return;
+
+        var self = this;
+
+        this.temperatureLoopJumpObserver = createObserver(
+            clip.path,
+            "loop_jump",
+            function(args) {
+                defer(function() {
+                    self.onTemperatureLoopJump();
+                });
+            }
+        );
+
+        this.observerRegistry.register('temperature_loop_jump', this.temperatureLoopJumpObserver);
+    };
+
+    /**
+     * Clear temperature loop_jump observer.
+     */
+    proto.clearTemperatureLoopJumpObserver = function() {
+        this.observerRegistry.unregister('temperature_loop_jump');
+        this.temperatureLoopJumpObserver = null;
+    };
+
+    /**
+     * Set temperature value with state transitions.
+     * V4.2: Extracted from temperature() function for use by OSC command handlers.
+     *
+     * Handles three transition types:
+     *   0 -> >0: Enable (capture original state)
+     *   >0 -> 0: Disable (restore original state)
+     *   >0 -> >0: Update (just change the value)
+     *
+     * @param {number} value - Temperature value (0.0-1.0)
+     */
+    proto.setTemperatureValue = function(value) {
+        var newTemperatureValue = Math.max(0.0, Math.min(1.0, parseFloat(value)));
+
+        // Detect transition type
+        var wasActive = this.temperatureValue > 0;
+        var willBeActive = newTemperatureValue > 0;
+
+        // Get current clip for state operations
+        var clip = this.getCurrentClip();
+        var clipId = clip ? clip.id : null;
+
+        // Handle state transitions
+        if (!wasActive && willBeActive) {
+            // Transition: 0 -> >0 (enable)
+            if (clipId) {
+                this.captureTemperatureState(clipId);
+            }
+            debug("temperature", "Enabled: captured original state");
+        } else if (wasActive && !willBeActive) {
+            // Transition: >0 -> 0 (disable)
+            if (clipId) {
+                this.restoreTemperatureState(clipId);
+            }
+            debug("temperature", "Disabled: restored original state");
+        }
+
+        // Update temperature value
+        this.temperatureValue = newTemperatureValue;
+        this.temperatureActive = willBeActive;
+
+        // Setup or clear loop jump observer
+        if (willBeActive) {
+            this.setupTemperatureLoopJumpObserver();
+        } else {
+            this.clearTemperatureLoopJumpObserver();
+        }
+
+        debug("temperature", "Set temperature to " + newTemperatureValue);
+    };
+
+    /**
+     * Capture original pitches by note ID for temperature transformation.
+     * Called when temperature transitions from 0 to >0.
+     *
+     * V3.1: Uses Live API note_id for robust tracking that handles:
+     * - Overdubbing (new notes simply won't exist in map)
+     * - Note deletion (missing IDs gracefully skipped)
+     * - Pitch sequencer interaction (accounts for current pitch state)
+     *
+     * @param {string} clipId - Clip ID to capture state for
+     */
+    proto.captureTemperatureState = function(clipId) {
+        var clip = this.getCurrentClip();
+        if (!clip || clip.id !== clipId) {
+            debug("captureTemperatureState", "Clip unavailable or ID mismatch");
+            return;
+        }
+
+        // Read current notes with note IDs
+        var notesJson = clip.call("get_all_notes_extended");
+        var notes = parseNotesResponse(notesJson);
+        if (!notes || !notes.notes || notes.notes.length === 0) {
+            debug("captureTemperatureState", "No notes to capture");
+            return;
+        }
+
+        // Calculate offset to get TRUE base pitch (before pitch sequencer shift)
+        // If pitch is on, notes are currently shifted +12, so subtract to get base
+        var pitchOffset = -this._getCurrentPitchOffset(clipId);
+
+        var pitchWasOn = this.lastValues[clipId] && this.lastValues[clipId].pitch === 1;
+
+        // Build originalPitches map: noteId -> base pitch
+        var originalPitches = {};
+        for (var i = 0; i < notes.notes.length; i++) {
+            var note = notes.notes[i];
+            originalPitches[note.note_id] = note.pitch + pitchOffset;
+        }
+
+        // Store state
+        this.temperatureState[clipId] = {
+            originalPitches: originalPitches,
+            capturedWithPitchOn: pitchWasOn
+        };
+
+        debug("captureTemperatureState", "Captured " + notes.notes.length + " notes for clip " + clipId, {
+            pitchWasOn: pitchWasOn,
+            sampleNoteIds: Object.keys(originalPitches).slice(0, 3)
+        });
+    };
+
+    /**
+     * Restore original pitches from note ID map.
+     * Called when temperature transitions from >0 to 0.
+     *
+     * V3.1: Restores each note to its original pitch by note ID.
+     * - Notes that were overdubbed (not in map) keep their current pitch
+     * - Accounts for current pitch sequencer state when restoring
+     *
+     * @param {string} clipId - Clip ID to restore state for
+     */
+    proto.restoreTemperatureState = function(clipId) {
+        var state = this.temperatureState[clipId];
+        if (!state) {
+            debug("restoreTemperatureState", "No state to restore for clip " + clipId);
+            return;
+        }
+
+        var clip = this.getCurrentClip();
+        if (!clip || clip.id !== clipId) {
+            debug("restoreTemperatureState", "Clip unavailable or ID mismatch");
+            delete this.temperatureState[clipId];
+            return;
+        }
+
+        // Read current notes
+        var notesJson = clip.call("get_all_notes_extended");
+        var notes = parseNotesResponse(notesJson);
+        if (!notes || !notes.notes) {
+            debug("restoreTemperatureState", "No notes to restore");
+            delete this.temperatureState[clipId];
+            return;
+        }
+
+        // Calculate pitch adjustment based on current pitch sequencer state
+        var pitchAdjustment = this._getCurrentPitchOffset(clipId);
+
+        // Restore each note's pitch from the map
+        var changed = false;
+        var restoredCount = 0;
+        var skippedCount = 0;
+
+        for (var i = 0; i < notes.notes.length; i++) {
+            var note = notes.notes[i];
+            var originalPitch = state.originalPitches[note.note_id];
+
+            if (originalPitch !== undefined) {
+                note.pitch = originalPitch + pitchAdjustment;
+                changed = true;
+                restoredCount++;
+            } else {
+                skippedCount++;
+            }
+        }
+
+        // Apply modifications if any changes were made
+        if (changed) {
+            try {
+                clip.call("apply_note_modifications", notes);
+                debug("restoreTemperatureState", "Restored " + restoredCount + " notes, skipped " + skippedCount + " (overdubs)");
+            } catch (err) {
+                handleError("restoreTemperatureState", err, false);
+            }
+        }
+
+        // Clear state
+        delete this.temperatureState[clipId];
+    };
+
+    /**
+     * Handle temperature loop jump.
+     * V3.1: Restores to original pitches first, then applies fresh random shuffle.
+     *
+     * This ensures temperature value directly controls "distance from original":
+     * - temp = 0.1: few swaps from original each loop
+     * - temp = 0.9: many swaps from original each loop
+     *
+     * Each loop is random but always based on the original pitches,
+     * not cumulative scrambling on top of previous scrambles.
+     */
+    proto.onTemperatureLoopJump = function() {
+        if (!this.temperatureActive || this.temperatureValue <= 0) return;
+
+        var clip = this.getCurrentClip();
+        if (!clip) return;
+
+        var clipId = clip.id;
+        var state = this.temperatureState[clipId];
+
+        // Need temperature state to know original pitches
+        if (!state) {
+            debug("onTemperatureLoopJump", "No temperature state for clip " + clipId);
+            return;
+        }
+
+        // 1. Read current notes
+        var notesJson = clip.call("get_all_notes_extended");
+        var notes = parseNotesResponse(notesJson);
+        if (!notes || !notes.notes) return;
+
+        // 2. Calculate pitch adjustment for current pitch sequencer state
+        var pitchAdjustment = this._getCurrentPitchOffset(clipId);
+
+        // 3. Restore all notes to original pitches first
+        for (var i = 0; i < notes.notes.length; i++) {
+            var note = notes.notes[i];
+            var originalPitch = state.originalPitches[note.note_id];
+            if (originalPitch !== undefined) {
+                note.pitch = originalPitch + pitchAdjustment;
+            }
+            // Overdubbed notes (not in map) keep their current pitch
+        }
+
+        // 4. Generate NEW random swap pattern based on temperature
+        this.temperatureSwapPattern = generateSwapPattern(
+            notes.notes,
+            this.temperatureValue
+        );
+
+        debug("temperature", "Generated " + this.temperatureSwapPattern.length + " swap groups from original");
+
+        // 5. Apply swaps to the restored original pitches
+        applySwapPattern(notes.notes, this.temperatureSwapPattern);
+
+        // 6. Apply to clip
+        try {
+            clip.call("apply_note_modifications", notes);
+            debug("temperature", "Applied temperature transformation from original");
+        } catch (err) {
+            handleError("onTemperatureLoopJump", err, false);
+        }
+    };
+}
+
+module.exports = {
+    applyTemperatureMethods: applyTemperatureMethods
+};

--- a/permute-utils.js
+++ b/permute-utils.js
@@ -1,0 +1,255 @@
+/**
+ * permute-utils.js - Utility functions
+ *
+ * Debug logging, error handling, observer creation, and other shared utilities.
+ *
+ * @requires permute-constants
+ */
+
+var constants = require('permute-constants');
+var TICKS_PER_QUARTER_NOTE = constants.TICKS_PER_QUARTER_NOTE;
+var DEFAULT_TIME_SIGNATURE = constants.DEFAULT_TIME_SIGNATURE;
+var INVALID_LIVE_API_ID = constants.INVALID_LIVE_API_ID;
+var TASK_SCHEDULE_DELAY = constants.TASK_SCHEDULE_DELAY;
+var TRANSPOSE_CONFIG = constants.TRANSPOSE_CONFIG;
+
+var DEBUG_MODE = false; // Set to true for development
+
+/**
+ * Debug logging utility.
+ * Only logs when DEBUG_MODE is enabled.
+ *
+ * @param {string} context - Context/location of the log
+ * @param {string} message - Message to log
+ * @param {*} data - Optional data to include
+ */
+function debug(context, message, data) {
+    if (DEBUG_MODE) {
+        var output = "[Sequencer DEBUG:" + context + "] " + message;
+        if (data !== undefined) {
+            output += " | Data: " + JSON.stringify(data);
+        }
+        post(output + "\n");
+    }
+}
+
+/**
+ * Handle errors consistently throughout the device.
+ * Logs errors to the Max console based on DEBUG_MODE and criticality.
+ *
+ * @param {string} context - Where the error occurred
+ * @param {Error|string} error - The error that occurred
+ * @param {boolean} isCritical - If true, always log; if false, only log in DEBUG_MODE
+ */
+function handleError(context, error, isCritical) {
+    if (DEBUG_MODE || isCritical) {
+        var errorMsg = error.toString ? error.toString() : String(error);
+        post("[Sequencer ERROR:" + context + "] " + errorMsg + "\n");
+    }
+}
+
+function post_error(msg) {
+    error("[Sequencer ERROR] " + msg + "\n");
+}
+
+/**
+ * Parse notes response from Live API call.
+ * Handles both string JSON format and array format.
+ *
+ * @param {*} notesJson - Response from get_all_notes_extended
+ * @returns {Object|null} - Parsed notes object with {notes: [...]} or null
+ */
+function parseNotesResponse(notesJson) {
+    if (!notesJson) return null;
+
+    if (typeof notesJson === "string") {
+        try {
+            var parsed = JSON.parse(notesJson);
+            if (parsed && parsed.notes && Array.isArray(parsed.notes)) {
+                return parsed;
+            } else if (Array.isArray(parsed)) {
+                return { notes: parsed };
+            }
+        } catch (err) {
+            handleError("parseNotesResponse", err, false);
+        }
+    } else if (Array.isArray(notesJson)) {
+        return { notes: notesJson };
+    }
+
+    return null;
+}
+
+/**
+ * Check if state change requires action.
+ * Used by pitch sequencer to avoid unnecessary API calls.
+ *
+ * @param {boolean} shouldApply - Desired state
+ * @param {boolean} currentState - Current state
+ * @returns {boolean} - True if change is needed
+ */
+function needsStateChange(shouldApply, currentState) {
+    return shouldApply !== currentState;
+}
+
+/**
+ * Get cached parameter API reference for a device.
+ * Creates a new LiveAPI object for the specified parameter.
+ *
+ * @param {LiveAPI} device - Device LiveAPI object
+ * @param {number} paramIndex - Parameter index
+ * @returns {LiveAPI} - Parameter LiveAPI object
+ */
+function getDeviceParameter(device, paramIndex) {
+    var paramPath = device.path + " parameters " + paramIndex;
+    return new LiveAPI(paramPath);
+}
+
+/**
+ * Find transpose parameter by scanning device parameters for known names.
+ * Returns the first match based on priority order from config.
+ * V4.0: Name-based parameter detection (case-insensitive, exact match).
+ *
+ * Performance: Scans up to 17 parameters (typical rack macro count).
+ * Called once per device load, not per-step.
+ *
+ * @param {LiveAPI} device - Device to scan
+ * @returns {Object|null} - { index, param, shiftAmount, name } or null if not found
+ */
+function findTransposeParameterByName(device) {
+    if (!device || device.id === INVALID_LIVE_API_ID) return null;
+
+    try {
+        var nameConfig = TRANSPOSE_CONFIG.parameterNames;
+        if (!nameConfig || nameConfig.length === 0) return null;
+
+        // Build lookup map (lowercase name -> config)
+        var nameLookup = {};
+        var priorityOrder = [];
+        for (var i = 0; i < nameConfig.length; i++) {
+            var entry = nameConfig[i];
+            var lowerName = entry.name.toLowerCase();
+            nameLookup[lowerName] = entry;
+            priorityOrder.push(lowerName);
+        }
+
+        // Get parameter count - limit to 17 (typical rack macro count)
+        var params = device.get("parameters");
+        if (!params) return null;
+        var paramCount = Math.min(Math.floor(params.length / 2), 17);
+        if (paramCount === 0) return null;
+
+        // Scan parameters, collecting matches
+        var matches = {};
+        for (var i = 0; i < paramCount; i++) {
+            var param = getDeviceParameter(device, i);
+
+            if (!param || param.id === INVALID_LIVE_API_ID) continue;
+
+            var nameResult = param.get("name");
+            if (nameResult && nameResult[0]) {
+                var paramName = nameResult[0].toLowerCase();
+                if (nameLookup[paramName]) {
+                    matches[paramName] = { index: i, param: param };
+                }
+            }
+        }
+
+        // Return highest priority match
+        for (var i = 0; i < priorityOrder.length; i++) {
+            var name = priorityOrder[i];
+            if (matches[name]) {
+                var config = nameLookup[name];
+                debug("transpose", "Found '" + name + "' at param " + matches[name].index);
+                return {
+                    index: matches[name].index,
+                    param: matches[name].param,
+                    shiftAmount: config.shiftAmount,
+                    name: name
+                };
+            }
+        }
+
+        return null;
+    } catch (err) {
+        handleError("findTransposeParameterByName", err, false);
+        return null;
+    }
+}
+
+/**
+ * Create and configure a LiveAPI observer.
+ * Centralizes the observer creation pattern used throughout the device.
+ *
+ * @param {string} path - LiveAPI path to observe
+ * @param {string} property - Property to observe
+ * @param {Function} callback - Callback function to execute on property change
+ * @returns {LiveAPI} - Configured LiveAPI observer
+ */
+function createObserver(path, property, callback) {
+    var observer = new LiveAPI(callback);
+    observer.path = path;
+    observer.property = property;
+    return observer;
+}
+
+/**
+ * Helper for deferred execution to break out of observer context.
+ * Live API calls from within observers must be deferred to avoid
+ * "Changes cannot be triggered by notifications" errors.
+ *
+ * @param {Function} callback - Function to execute on next tick
+ */
+function defer(callback) {
+    if (typeof Task !== 'undefined') {
+        var t = new Task(callback, this);
+        t.schedule(TASK_SCHEDULE_DELAY);
+    } else {
+        callback.apply(this);
+    }
+}
+
+/**
+ * Calculate ticks per step based on division and time signature.
+ * @param {Array|string} division - Division format
+ * @param {number} timeSignature - Time signature numerator
+ * @returns {number} - Ticks per step
+ */
+function calculateTicksPerStep(division, timeSignature) {
+    if (typeof division === "string") {
+        switch(division) {
+            case "1/1":  return TICKS_PER_QUARTER_NOTE * 4;
+            case "1/2":  return TICKS_PER_QUARTER_NOTE * 2;
+            case "1/4":  return TICKS_PER_QUARTER_NOTE;
+            case "1/8":  return TICKS_PER_QUARTER_NOTE / 2;
+            case "1/16": return TICKS_PER_QUARTER_NOTE / 4;
+            case "1/32": return TICKS_PER_QUARTER_NOTE / 8;
+            case "1/64": return TICKS_PER_QUARTER_NOTE / 16;
+            default: return TICKS_PER_QUARTER_NOTE / 4;
+        }
+    } else if (Array.isArray(division) && division.length === 3) {
+        var bars = division[0];
+        var beats = division[1];
+        var ticks = division[2];
+        var beatsPerBar = timeSignature || DEFAULT_TIME_SIGNATURE;
+        return (bars * beatsPerBar * TICKS_PER_QUARTER_NOTE) +
+               (beats * TICKS_PER_QUARTER_NOTE) +
+               ticks;
+    }
+
+    return TICKS_PER_QUARTER_NOTE / 4;
+}
+
+module.exports = {
+    DEBUG_MODE: DEBUG_MODE,
+    debug: debug,
+    handleError: handleError,
+    post_error: post_error,
+    parseNotesResponse: parseNotesResponse,
+    needsStateChange: needsStateChange,
+    getDeviceParameter: getDeviceParameter,
+    findTransposeParameterByName: findTransposeParameterByName,
+    createObserver: createObserver,
+    defer: defer,
+    calculateTicksPerStep: calculateTicksPerStep
+};


### PR DESCRIPTION
Phase 1: Fix state persistence bug (Issue #4)
- Rewrite restoreState() as thin adapter delegating to setState(), ensuring
  all setter side effects fire (observer activation, tick calculation,
  temperature state management)
- Exclude 'init' origin from pattr_state output to prevent default state
  overwriting saved data on load
- Clean up verbose investigation logging in getvalueof()/setvalueof()

Phase 2: Add initialization lifecycle management
- Add 'initialized' flag preventing pattr_state output during init/restore
- Set flag in init(), restoreState(), and setvalueof() for all paths
- Add [INIT-SEQUENCE] logging for empirical startup order documentation

Phase 3: Modularize into focused CommonJS modules
- Extract 9 modules: constants, utils, sequencer, observer-registry, state,
  instruments, commands, shuffle, temperature
- Temperature uses mixin pattern applied to SequencerDevice.prototype
- Consolidate 3 duplicated pitch offset calculations into _getCurrentPitchOffset()
- Rename lastAppliedValue -> lastParameterValue for clarity
- Fix stale notifydeleted() reference to removed transformations path
- Main file reduced from ~3013 to ~1741 lines

Phase 4: Documentation
- ADR-003: Robust State Restoration (Phases 1-2)
- ADR-004: Modularization (Phase 3)
- Updated CLAUDE.md key files table
- Added implementation log to robustness-refactor-plan.md

https://claude.ai/code/session_01RabNyDMva9UCYHaWoBVgHK