### PR TITLE
feat(temperature): base-model architecture for lossless return-to-zero

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"ca9f8847-07b7-456e-9d51-aac4c7eb308d","pid":70635,"procStart":"Mon May 25 21:46:56 2026","acquiredAt":1779746915419}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,12 +59,20 @@ Tracks `lastValues` per clip, applies deltas only on change:
 - `TransposeStrategy` - Parameter-based pitch shifting
 - `ObserverRegistry` - Centralized Live API observer management
 
-### Temperature Transformation (v3.1)
+### Temperature Transformation (v3.3 — base model)
 
-Uses note ID tracking for reversible pitch swapping:
-- Captures original pitches by `note_id` when temp goes 0→>0
-- Restores original pitches when temp goes >0→0
-- Handles overdubbing (new notes preserved) and deletion gracefully
+The user's composition is the source of truth, held in an in-memory **base
+model** per clip; the scrambled clip is never read back as truth. Each variation
+is derived from the base model (`displayed = applySwap(baseModel, temp)`), so
+return-to-0 rewrites the base verbatim and is lossless by construction. See
+`docs/adr/015-temperature-base-model.md`.
+- Captures full base notes by `note_id` when temp goes 0→>0
+- Variations (enable, loop jump, post-edit) always derive from the base model
+- Return-to-0 rewrites the base model verbatim (+ current pitch-seq offset)
+- Transport stop writes the original back to the clip but keeps the base model
+  in memory; transport start re-derives (no re-capture from the live clip)
+- A `notes` observer + content diff distinguishes our own writes from user edits
+  (timing-independent); a user edit while hot re-baselines to the new notes
 
 ### Note Chance (v3.2)
 

--- a/docs/adr/015-temperature-base-model.md
+++ b/docs/adr/015-temperature-base-model.md
@@ -1,0 +1,117 @@
+# ADR 015: Temperature Base Model (lossless return-to-zero)
+
+**Status:** Accepted
+**Date:** 2026-05-25
+**Supersedes the temperature state mechanism in:** ADR 106 (reference/106-temperature-transformation-architecture.md)
+
+## Context
+
+Returning the temperature control to 0 was supposed to restore the clip to its
+pristine original. In practice notes were lost. The id-tracking math itself was
+correct — a Node simulation of 200 loop jumps followed by return-to-0 was
+lossless — but the *state that defined "original"* was being destroyed and
+rebuilt at the wrong moments:
+
+1. **Transport stop deleted `temperatureState`** while keeping
+   `temperatureValue > 0`. The next transport start re-captured whatever
+   pitches were currently in the clip as the new "original." If anything had
+   scrambled them first, the scramble became the baseline and the true original
+   was gone forever. This is the "same clip, never switched" failure.
+2. **A deferred `loop_jump` callback could race return-to-0**, applying a swap
+   after the restore had already run and deleted the state, leaving notes
+   scrambled with nothing left to undo.
+3. **Overdubbed notes corrupted the clip**: an overdubbed note could steal a
+   captured note's pitch via a swap, and that wrong pitch stuck permanently.
+
+The root cause is architectural: the design treated *the clip itself* as the
+storage for the original and relied on being able to reverse every scramble.
+Reversibility had to be actively maintained, and every place that rebuilt the
+reverse-map was a chance to capture a corrupted baseline.
+
+## Decision
+
+The user's composition is the **source of truth**, held in an in-memory **base
+model** per clip. The scrambled clip is never read back as truth.
+
+```
+displayed = applySwap(baseModel, temperature)
+```
+
+- **Base model:** `clipId -> { baseModel: { noteId -> {pitch,start_time,…} }, expected }`.
+  Full note dicts (not just pitch) keyed by `note_id`, with the *true* base
+  pitch (any pitch-sequencer octave shift removed).
+- **Every variation** (initial enable, loop jump, post-edit) is derived by
+  resetting known notes to their base pitch, generating a fresh swap, and
+  writing. Variation is therefore non-cumulative by construction — it always
+  starts from the base, never from the previous scramble.
+- **Return to 0** rewrites the base model verbatim (+ current pitch-sequencer
+  offset). Lossless by definition; it does not "reverse N swaps."
+- **Transport stop** writes the base model back to the clip (so a saved Live set
+  is clean) but **keeps the base model in memory**. Transport start re-derives
+  from it instead of re-capturing from the live clip. The re-capture-on-start
+  path is removed.
+
+### Detecting user edits while hot (content diff, timing-independent)
+
+Live fires the `notes` notification for our own writes as well as user edits.
+We distinguish them by **content**, not timing:
+
+- Before each write we record `expected = { noteId -> pitch }` — the exact
+  pitches we are about to write. `expected` is recorded **before** the
+  `apply_note_modifications` call, because that call queues the notification
+  synchronously; recording after would race it.
+- On a `notes` notification we read the clip and compare to `expected`:
+  - exact match → our own swap write → ignore.
+  - different id-set (add/remove) or any existing note repitched away from
+    `expected` → **user edit** → re-baseline.
+
+Because the decision is content-based, correctness no longer depends on which
+callback runs first — this is what eliminates the loop-jump race.
+
+### Re-baseline policy
+
+A user edit while hot **supersedes** the prior original (accepted tradeoff, by
+design): the current notes become the new base model. Notes we recognise that
+the user did *not* touch (still at their `expected` swap pitch) are reverted to
+base before snapshotting, so the new base reflects the user's composition rather
+than our scramble. Notes the user added or repitched are kept as the new intent.
+A fresh variation is then applied so playback stays consistent.
+
+## Consequences
+
+### Positive
+- Return-to-0 is provably lossless (single clip, across transport cycles, with
+  pitch sequencer active).
+- The loop-jump / return-to-0 race is gone (content diff, not timing).
+- Overdubs and deliberate edits while hot no longer corrupt the clip; they
+  re-baseline cleanly.
+- The clip on disk is always clean after transport stop, so saved sets are safe.
+
+### Negative / tradeoffs
+- The pre-edit original is intentionally discarded when the user edits while
+  hot. This was an explicit decision: an edit is treated as new intent.
+- Base model is in-memory only; it does not survive closing/reopening the Live
+  set while temperature is hot. Acceptable because transport stop always writes
+  the clean original back to the clip, so nothing is lost on disk.
+- If a user edit lands in the *same* notification coalesce window as one of our
+  writes, that edit may not be re-baselined until the next change. Downside is a
+  delayed re-baseline, never corruption.
+
+## Verification
+
+`get_all_notes_extended` / `apply_note_modifications` were exercised against a
+mock clip with the real `permute-temperature.js` and `permute-shuffle.js`:
+
+- 200 loop jumps on one clip → return-to-0 lossless.
+- Transport stop writes original; stop/start cycles → return-to-0 lossless.
+- Overdub while hot → originals restored, overdub preserved.
+- User repitches an existing note while hot → that note becomes new base,
+  others restore.
+- Pitch sequencer on during temperature → return-to-0 keeps the octave shift.
+
+## Files
+
+- `permute-temperature.js` — base model capture/restore/variation, notes
+  observer, content diff, re-baseline.
+- `permute-device.js` — transport start/stop, `onClipChanged`, `_setCachedClip`,
+  `temperatureState` shape.

--- a/docs/adr/015-temperature-base-model.md
+++ b/docs/adr/015-temperature-base-model.md
@@ -77,6 +77,31 @@ base before snapshotting, so the new base reflects the user's composition rather
 than our scramble. Notes the user added or repitched are kept as the new intent.
 A fresh variation is then applied so playback stays consistent.
 
+### Overdubs are never swapped until re-baselined
+
+`applyTemperatureVariation` swaps only notes present in the base model. An
+overdubbed note that is not yet folded in (its `notes` notification still
+pending) is excluded from the swap pool, so it always keeps its recorded pitch.
+Without this, a return-to-0 that lands *before* the notes observer fires would
+leave the overdub at a scrambled pitch — `restoreBaseModel` only restores
+base-model notes. Excluding non-base notes closes that window entirely.
+
+### Disarm before restore on transport stop
+
+On transport stop, the temperature observers are torn down and
+`temperatureActive` is cleared **before** the notes are read and the base model
+is written back. This guarantees any already-queued deferred
+`onTemperatureNotesChanged` callback sees inactive state and bails, rather than
+racing the restore write (which sets `expected = null`) and triggering a
+spurious re-baseline of the just-cleaned clip.
+
+### `captureBaseModel` self-enforces no-overwrite
+
+Capture returns early if a base model already exists for the clip, so the
+"never overwrite except via re-baseline" contract holds even if a future caller
+forgets to guard. Re-baseline assigns `temperatureState` directly and is the
+only path that replaces an existing base model.
+
 ## Consequences
 
 ### Positive
@@ -100,14 +125,19 @@ A fresh variation is then applied so playback stays consistent.
 ## Verification
 
 `get_all_notes_extended` / `apply_note_modifications` were exercised against a
-mock clip with the real `permute-temperature.js` and `permute-shuffle.js`:
+mock clip with the real `permute-temperature.js` and `permute-shuffle.js`. The
+notes notification is modelled as an async, manually-drained queue (matching
+Max's `defer`) so callback ordering can be controlled:
 
 - 200 loop jumps on one clip → return-to-0 lossless.
 - Transport stop writes original; stop/start cycles → return-to-0 lossless.
-- Overdub while hot → originals restored, overdub preserved.
+- Overdub while hot, observer drained → re-baselined, overdub preserved.
 - User repitches an existing note while hot → that note becomes new base,
   others restore.
 - Pitch sequencer on during temperature → return-to-0 keeps the octave shift.
+- **Race:** overdub → loop variation → return-to-0 *before* the notes observer
+  fires → overdub kept at its recorded pitch. Confirmed to fail with the
+  pre-fix full-array swap and pass with the base-note-only swap.
 
 ## Files
 

--- a/docs/reference/106-temperature-transformation-architecture.md
+++ b/docs/reference/106-temperature-transformation-architecture.md
@@ -1,6 +1,6 @@
 # ADR 106: Temperature Transformation for Organic Loop Variation
 
-> **HISTORICAL — pre-Permute Looping-repo ADR.** Preserved for archival context. Temperature still exists in Permute with the same algorithmic core, but the "two-phase layer system" and the "parameter 21" reference below pre-date the delta-based refactor and the UI-native revamp. For the current architecture see [../../CLAUDE.md](../../CLAUDE.md) and for the current parameter layout see [../api.md](../api.md).
+> **HISTORICAL — pre-Permute Looping-repo ADR.** Preserved for archival context. Temperature still exists in Permute with the same algorithmic core (group-based swap), but the "two-phase layer system" and the "parameter 21" reference below pre-date the delta-based refactor and the UI-native revamp. The state/reversibility mechanism described here (capture original pitches, reverse swaps to restore) has been **superseded by the base-model architecture** — see [../adr/015-temperature-base-model.md](../adr/015-temperature-base-model.md). For the current architecture see [../../CLAUDE.md](../../CLAUDE.md) and for the current parameter layout see [../api.md](../api.md).
 
 **Status:** Accepted (algorithm still in use; surrounding architecture superseded)
 **Date:** 2025-11-05

--- a/permute-device.js
+++ b/permute-device.js
@@ -80,9 +80,17 @@ function SequencerDevice() {
     this.temperatureSwapPattern = [];
     this.temperatureActive = false;
     this.temperatureLoopJumpObserver = null;
+    this.temperatureNotesObserver = null;
 
-    // Temperature note ID tracking for reversible transformations
-    // Maps clipId -> { originalPitches: { noteId: pitch } }
+    // Temperature base model: the user's composition is the source of truth,
+    // never the scrambled clip. Maps clipId -> {
+    //   baseModel: { noteId: {pitch,start_time,duration,velocity,mute,
+    //                         probability,velocity_deviation,release_velocity} },
+    //   expected:  { noteId: pitch }   // pitches WE last wrote, for self-write diff
+    // }
+    // Variations are always derived from baseModel; return-to-0 rewrites it
+    // verbatim. A notes-changed that doesn't match `expected` means the user
+    // edited the clip -> re-baseline. See docs/adr/015-temperature-base-model.md.
     this.temperatureState = {};
 
     // Chance (note probability) state (non-sequenced)
@@ -388,17 +396,22 @@ SequencerDevice.prototype.onTransportStart = function() {
     this.invalidateClipCache();
     this.transportState.setPlaying(true);
 
-    // If temperature was set before transport started, capture state now
+    // If temperature is hot, derive a fresh variation from the base model.
+    // The base model is the source of truth and persists across transport
+    // cycles; we capture it only if it doesn't exist yet (never overwrite it
+    // from the live clip, which may already be scrambled).
     if (this.temperatureValue > 0) {
         var clip = this.getCurrentClip();
         if (clip) {
             var clipId = clip.id;
-            // Only capture if we don't already have state for this clip
+            this.temperatureActive = true;
             if (!this.temperatureState[clipId]) {
-                this.captureTemperatureState(clipId);
+                this.captureBaseModel(clipId);
             }
+            this.setupTemperatureLoopJumpObserver();
+            this.setupTemperatureNotesObserver();
+            this.applyTemperatureVariation(clipId);
         }
-        this.setupTemperatureLoopJumpObserver();
     }
 
     // Apply chance to clip if active
@@ -450,21 +463,25 @@ SequencerDevice.prototype.onTransportStop = function() {
                     var changed = false;
 
                     if (hasTemperatureState) {
+                        // Write the base model (true original) back to the clip
+                        // so a saved set is clean, but KEEP the base model in
+                        // memory so the next transport start re-derives from it.
                         var tempState = this.temperatureState[clipId];
                         for (var i = 0; i < notes.notes.length; i++) {
                             var note = notes.notes[i];
-                            var originalPitch = tempState.originalPitches[note.note_id];
-                            if (originalPitch !== undefined) {
+                            var base = tempState.baseModel[note.note_id];
+                            if (base) {
                                 // Restore TRUE base pitch (no pitch sequencer adjustment)
-                                note.pitch = originalPitch;
+                                note.pitch = base.pitch;
                                 changed = true;
                             }
-                            // Overdubbed notes keep current pitch
+                            // Overdubbed notes not yet re-baselined keep current pitch
                         }
-                        debug("onTransportStop", "Restored temperature state for " + notes.notes.length + " notes");
-
-                        // Clear temperature state
-                        delete this.temperatureState[clipId];
+                        // We just wrote base pitches; the notes observer is torn
+                        // down below, but record expected defensively in case a
+                        // notification is already queued.
+                        tempState.expected = null;
+                        debug("onTransportStop", "Restored base model for " + notes.notes.length + " notes (kept in memory)");
                     } else {
                         // No temperature state - use delta-based pitch undo for note_transpose
                         if (this.lastValues[clipId] && this.lastValues[clipId].pitch === 1) {
@@ -523,10 +540,12 @@ SequencerDevice.prototype.onTransportStop = function() {
         }
     }
 
-    // Clear temperature observer (will be re-setup on next transport start if temp > 0)
+    // Clear temperature observers (re-setup on next transport start if temp > 0).
+    // The base model stays in memory and is re-derived from on restart.
     this.clearTemperatureLoopJumpObserver();
+    this.clearTemperatureNotesObserver();
 
-    // Clear active flag but keep temperatureValue across transport cycles
+    // Clear active flag but keep temperatureValue and base model across cycles
     this.temperatureActive = false;
 
     // Cancel any pending batch applies
@@ -953,13 +972,14 @@ SequencerDevice.prototype._refreshClipFromSlots = function() {
 
 /**
  * Update _cachedClip / _cachedClipId. On identity change, clear the
- * temperature loop_jump observer and update clipState — same cleanup the
- * old per-tick getCurrentClip used to do when clip.id changed.
+ * temperature observers (loop_jump + notes) and update clipState — same
+ * cleanup the old per-tick getCurrentClip used to do when clip.id changed.
  */
 SequencerDevice.prototype._setCachedClip = function(clip, clipPath) {
     var newId = clip ? clip.id : null;
     if (newId !== this._cachedClipId) {
         this.clearTemperatureLoopJumpObserver();
+        this.clearTemperatureNotesObserver();
         this.clipState.update(newId);
     }
     this._cachedClip = clip;
@@ -1127,29 +1147,31 @@ SequencerDevice.prototype.handleMaxUICommand = function(messageName, args) {
 };
 
 /**
- * Handle clip change event.
- * Cleans up temperature state for old clip, re-captures for new clip if active.
+ * Handle clip change event (the device's target clip changed).
+ * Re-points temperature observers at the new clip. Base models are keyed by
+ * clipId and kept, so returning to a previously-hot clip preserves its
+ * original; the new clip captures its own base model on first hot use.
  */
 SequencerDevice.prototype.onClipChanged = function() {
     this.invalidateClipCache();
-    var hasTemperatureState = false;
-    for (var k in this.temperatureState) {
-        if (this.temperatureState.hasOwnProperty(k)) {
-            hasTemperatureState = true;
-            break;
-        }
-    }
-    if (hasTemperatureState) {
-        this.temperatureState = {};
-        debug("onClipChanged", "Cleared temperature state for old clip");
-    }
 
-    // If temperature is active, capture state for the new clip
+    // Detach observers from the old clip path.
+    this.clearTemperatureLoopJumpObserver();
+    this.clearTemperatureNotesObserver();
+
+    // If temperature is active, set up the new clip: capture its base model if
+    // we don't have one for it yet (never overwrite an existing base model),
+    // re-point observers, and apply a fresh variation.
     if (this.temperatureValue > 0 && this.temperatureActive) {
         var clip = this.getCurrentClip();
         if (clip) {
-            this.captureTemperatureState(clip.id);
-            debug("onClipChanged", "Captured temperature state for new clip");
+            if (!this.temperatureState[clip.id]) {
+                this.captureBaseModel(clip.id);
+            }
+            this.setupTemperatureLoopJumpObserver();
+            this.setupTemperatureNotesObserver();
+            this.applyTemperatureVariation(clip.id);
+            debug("onClipChanged", "Re-pointed temperature to new clip");
         }
     }
 

--- a/permute-device.js
+++ b/permute-device.js
@@ -453,6 +453,15 @@ SequencerDevice.prototype.onTransportStop = function() {
 
     var hasTemperatureState = !!this.temperatureState[clipId];
 
+    // Disarm temperature BEFORE touching notes: tear down the observers and
+    // clear the active flag so any already-queued deferred onTemperatureNotes-
+    // Changed callback sees inactive state and bails, rather than racing the
+    // restore-write below (which sets expected = null) and triggering a spurious
+    // re-baseline. The base model stays in memory; we re-derive on next start.
+    this.clearTemperatureLoopJumpObserver();
+    this.clearTemperatureNotesObserver();
+    this.temperatureActive = false;
+
     // Undo transformations based on last values
     if (this.lastValues[clipId] || hasTemperatureState) {
         try {
@@ -540,13 +549,9 @@ SequencerDevice.prototype.onTransportStop = function() {
         }
     }
 
-    // Clear temperature observers (re-setup on next transport start if temp > 0).
-    // The base model stays in memory and is re-derived from on restart.
-    this.clearTemperatureLoopJumpObserver();
-    this.clearTemperatureNotesObserver();
-
-    // Clear active flag but keep temperatureValue and base model across cycles
-    this.temperatureActive = false;
+    // Temperature observers and the active flag were already disarmed above,
+    // before the notes block. temperatureValue and the base model persist across
+    // cycles and are re-derived from on the next transport start.
 
     // Cancel any pending batch applies
     for (var pendingClipId in this.pendingApplies) {

--- a/permute-temperature.js
+++ b/permute-temperature.js
@@ -3,6 +3,17 @@
  *
  * Applied as a mixin to SequencerDevice.prototype.
  * Depends on: permute-constants, permute-utils, permute-shuffle
+ *
+ * Model (ADR 015): the user's composition is the source of truth, held in an
+ * in-memory base model per clip. Temperature is a pure function of the base
+ * model: displayed = applySwap(baseModel, temp). The scrambled clip is NEVER
+ * read back as truth. Return-to-0 rewrites the base model verbatim.
+ *
+ * User edits while temperature is hot are detected by a content diff: after
+ * every write we record the exact pitches we wrote (`expected`). A notes-changed
+ * notification whose contents differ from `expected` (added/removed/repitched
+ * notes) means the user changed the clip -> we re-baseline to current notes.
+ * This makes correctness independent of callback ordering.
  */
 
 var constants = require('permute-constants');
@@ -18,10 +29,15 @@ var defer = utils.defer;
 var generateSwapPattern = shuffle.generateSwapPattern;
 var applySwapPattern = shuffle.applySwapPattern;
 
+// Note fields preserved in the base model so return-to-0 restores the full
+// note, not just pitch.
+var BASE_MODEL_FIELDS = [
+    'pitch', 'start_time', 'duration', 'velocity', 'mute',
+    'probability', 'velocity_deviation', 'release_velocity'
+];
+
 /**
  * Apply temperature methods to SequencerDevice.prototype.
- * This mixin pattern keeps temperature logic in a separate file
- * while attaching methods to the main device class.
  *
  * @param {Object} proto - SequencerDevice.prototype
  */
@@ -29,11 +45,10 @@ function applyTemperatureMethods(proto) {
 
     /**
      * Get current pitch offset for temperature calculations.
-     * Consolidates the duplicated pitch offset logic from capture, restore, and loop jump.
      *
-     * Returns the semitone offset currently applied by the pitch sequencer via note modification.
-     * Returns 0 if pitch sequencer is off or if using parameter-based transpose (where notes
-     * aren't directly shifted).
+     * Returns the semitone offset currently applied by the pitch sequencer via
+     * note modification. Returns 0 if pitch sequencer is off or if using
+     * parameter-based transpose (where notes aren't directly shifted).
      *
      * @param {string} clipId - Clip ID to check pitch state for
      * @returns {number} - Current pitch offset in semitones (0 or OCTAVE_SEMITONES)
@@ -45,6 +60,8 @@ function applyTemperatureMethods(proto) {
         }
         return 0;
     };
+
+    // ===== OBSERVERS =====
 
     proto.setupTemperatureLoopJumpObserver = function() {
         this.clearTemperatureLoopJumpObserver();
@@ -67,178 +84,339 @@ function applyTemperatureMethods(proto) {
         this.observerRegistry.register('temperature_loop_jump', this.temperatureLoopJumpObserver);
     };
 
-    /**
-     * Clear temperature loop_jump observer.
-     */
     proto.clearTemperatureLoopJumpObserver = function() {
         this.observerRegistry.unregister('temperature_loop_jump');
         this.temperatureLoopJumpObserver = null;
     };
 
     /**
+     * Observe the clip's notes so user edits made while temperature is hot can
+     * be detected and folded into the base model (re-baseline). Live fires the
+     * "notes" notification for our own writes too; the content diff in
+     * onTemperatureNotesChanged distinguishes them.
+     */
+    proto.setupTemperatureNotesObserver = function() {
+        this.clearTemperatureNotesObserver();
+
+        var clip = this.getCurrentClip();
+        if (!clip) return;
+
+        var self = this;
+
+        this.temperatureNotesObserver = createObserver(
+            clip.path,
+            "notes",
+            function(args) {
+                defer(function() {
+                    self.onTemperatureNotesChanged();
+                });
+            }
+        );
+
+        this.observerRegistry.register('temperature_notes', this.temperatureNotesObserver);
+    };
+
+    proto.clearTemperatureNotesObserver = function() {
+        this.observerRegistry.unregister('temperature_notes');
+        this.temperatureNotesObserver = null;
+    };
+
+    // ===== BASE MODEL HELPERS =====
+
+    /**
+     * Build a base model (noteId -> full note dict) from a notes array.
+     * Pitches are stored as TRUE base pitch (pitch sequencer shift removed).
+     *
+     * @param {Array} notes - notes from get_all_notes_extended
+     * @param {number} pitchShift - current pitch sequencer offset to subtract
+     * @returns {Object} - baseModel keyed by note_id
+     */
+    proto._buildBaseModel = function(notes, pitchShift) {
+        var baseModel = {};
+        for (var i = 0; i < notes.length; i++) {
+            var note = notes[i];
+            var entry = {};
+            for (var f = 0; f < BASE_MODEL_FIELDS.length; f++) {
+                var field = BASE_MODEL_FIELDS[f];
+                if (note[field] !== undefined) entry[field] = note[field];
+            }
+            // Store TRUE base pitch (before any pitch sequencer shift)
+            entry.pitch = note.pitch - pitchShift;
+            entry.note_id = note.note_id;
+            baseModel[note.note_id] = entry;
+        }
+        return baseModel;
+    };
+
+    /**
+     * Read current clip notes. Returns parsed {notes:[...]} or null.
+     */
+    proto._readClipNotes = function(clip) {
+        var notesJson = clip.call("get_all_notes_extended");
+        return parseNotesResponse(notesJson);
+    };
+
+    /**
+     * Record the pitches we just wrote so the notes observer can recognise our
+     * own write and not mistake it for a user edit.
+     *
+     * @param {Array} notes - notes as written to the clip
+     * @param {string} clipId
+     */
+    proto._recordExpected = function(notes, clipId) {
+        var state = this.temperatureState[clipId];
+        if (!state) return;
+        var expected = {};
+        for (var i = 0; i < notes.length; i++) {
+            expected[notes[i].note_id] = notes[i].pitch;
+        }
+        state.expected = expected;
+    };
+
+    /**
+     * Decide whether the current clip notes are an external (user) change vs.
+     * our own last write. Returns true if the user changed the clip.
+     *
+     * A swap only permutes pitches among existing note ids. So:
+     *   - a different id-set (add/remove)      -> user change
+     *   - a note repitched away from expected  -> user change
+     *   - exact match to expected              -> our own write
+     *
+     * @param {Array} notes - current clip notes
+     * @param {Object} expected - { noteId: pitch } we last wrote
+     * @returns {boolean}
+     */
+    proto._isExternalChange = function(notes, expected) {
+        if (!expected) return true;
+
+        // id-set size differs -> add/remove
+        var expectedCount = 0;
+        for (var k in expected) {
+            if (expected.hasOwnProperty(k)) expectedCount++;
+        }
+        if (notes.length !== expectedCount) return true;
+
+        for (var i = 0; i < notes.length; i++) {
+            var note = notes[i];
+            if (!expected.hasOwnProperty(note.note_id)) {
+                return true; // unknown id -> added (and something removed)
+            }
+            if (expected[note.note_id] !== note.pitch) {
+                return true; // existing note repitched by the user
+            }
+        }
+        return false;
+    };
+
+    // ===== TEMPERATURE VALUE / TRANSITIONS =====
+
+    /**
      * Set temperature value with state transitions.
-     * Handles 0->active and active->0 transitions (capture/restore).
+     * 0->active: capture base model + start observers + apply first variation.
+     * active->0: restore base model verbatim + stop observers.
      *
      * @param {number} value - Temperature value (0.0-1.0)
      */
     proto.setTemperatureValue = function(value) {
         var newTemperatureValue = Math.max(0.0, Math.min(1.0, parseFloat(value)));
 
-        // Detect transition type
         var wasActive = this.temperatureValue > 0;
         var willBeActive = newTemperatureValue > 0;
 
-        // Get current clip for state operations
         var clip = this.getCurrentClip();
         var clipId = clip ? clip.id : null;
 
-        // Handle state transitions
-        if (!wasActive && willBeActive) {
-            // Transition: 0 -> >0 (enable)
-            if (clipId) {
-                this.captureTemperatureState(clipId);
-            }
-            debug("temperature", "Enabled: captured original state");
-        } else if (wasActive && !willBeActive) {
-            // Transition: >0 -> 0 (disable)
-            if (clipId) {
-                this.restoreTemperatureState(clipId);
-            }
-            debug("temperature", "Disabled: restored original state");
-        }
-
-        // Update temperature value
+        // Update value first so writes derive from the new temperature.
         this.temperatureValue = newTemperatureValue;
         this.temperatureActive = willBeActive;
 
-        // Setup or clear loop jump observer only on actual transitions
         if (!wasActive && willBeActive) {
-            this.setupTemperatureLoopJumpObserver();
+            // 0 -> >0 (enable)
+            if (clipId) {
+                this.captureBaseModel(clipId);
+                this.setupTemperatureLoopJumpObserver();
+                this.setupTemperatureNotesObserver();
+                // Apply an immediate variation so the effect is audible without
+                // waiting for the first loop jump.
+                this.applyTemperatureVariation(clipId);
+            }
+            debug("temperature", "Enabled: captured base model");
         } else if (wasActive && !willBeActive) {
+            // >0 -> 0 (disable): restore the base model verbatim.
             this.clearTemperatureLoopJumpObserver();
+            this.clearTemperatureNotesObserver();
+            if (clipId) {
+                this.restoreBaseModel(clipId);
+            }
+            debug("temperature", "Disabled: restored base model");
         }
 
         debug("temperature", "Set temperature to " + newTemperatureValue);
     };
 
     /**
-     * Capture original pitches by note ID for temperature transformation.
-     * Called when temperature transitions from 0 to >0.
-     * Handles overdubbing (new notes not in map) and note deletion (IDs skipped).
+     * Capture the base model (true original) for a clip. Called once when
+     * temperature goes hot, on transport start if missing, and on clip change.
+     * Never overwrites an existing base model except via re-baseline.
      *
-     * @param {string} clipId - Clip ID to capture state for
+     * @param {string} clipId
      */
-    proto.captureTemperatureState = function(clipId) {
+    proto.captureBaseModel = function(clipId) {
         var clip = this.getCurrentClip();
         if (!clip || clip.id !== clipId) {
-            debug("captureTemperatureState", "Clip unavailable or ID mismatch");
+            debug("captureBaseModel", "Clip unavailable or ID mismatch");
             return;
         }
 
-        // Read current notes with note IDs
-        var notesJson = clip.call("get_all_notes_extended");
-        var notes = parseNotesResponse(notesJson);
+        var notes = this._readClipNotes(clip);
         if (!notes || !notes.notes || notes.notes.length === 0) {
-            debug("captureTemperatureState", "No notes to capture");
+            debug("captureBaseModel", "No notes to capture");
             return;
         }
 
-        // Calculate offset to get TRUE base pitch (before pitch sequencer shift)
-        // If pitch is on, notes are currently shifted +12, so subtract to get base
-        var pitchOffset = -this._getCurrentPitchOffset(clipId);
+        var pitchShift = this._getCurrentPitchOffset(clipId);
+        var baseModel = this._buildBaseModel(notes.notes, pitchShift);
 
-        // Build originalPitches map: noteId -> base pitch
-        var originalPitches = {};
-        for (var i = 0; i < notes.notes.length; i++) {
-            var note = notes.notes[i];
-            // Store the TRUE base pitch (accounting for any pitch sequencer shift)
-            originalPitches[note.note_id] = note.pitch + pitchOffset;
-        }
-
-        // Store state
         this.temperatureState[clipId] = {
-            originalPitches: originalPitches
+            baseModel: baseModel,
+            expected: null
         };
 
-        debug("captureTemperatureState", "Captured " + notes.notes.length + " notes for clip " + clipId, {
-            sampleNoteIds: Object.keys(originalPitches).slice(0, 3)
-        });
+        debug("captureBaseModel", "Captured " + notes.notes.length + " notes for clip " + clipId);
     };
 
     /**
-     * Restore original pitches from note ID map.
-     * Called when temperature transitions from >0 to 0.
-     * Overdubbed notes (not in map) keep their current pitch.
+     * Restore the base model verbatim (all fields), then clear temperature
+     * state. Notes the user added after capture are removed only if they were
+     * never folded in; in practice re-baseline keeps the model current, so the
+     * base model is authoritative and we restore exactly it.
      *
-     * @param {string} clipId - Clip ID to restore state for
+     * @param {string} clipId
      */
-    proto.restoreTemperatureState = function(clipId) {
+    proto.restoreBaseModel = function(clipId) {
         var state = this.temperatureState[clipId];
         if (!state) {
-            debug("restoreTemperatureState", "No state to restore for clip " + clipId);
+            debug("restoreBaseModel", "No state to restore for clip " + clipId);
             return;
         }
 
         var clip = this.getCurrentClip();
         if (!clip || clip.id !== clipId) {
-            debug("restoreTemperatureState", "Clip unavailable or ID mismatch");
+            debug("restoreBaseModel", "Clip unavailable or ID mismatch");
             delete this.temperatureState[clipId];
             return;
         }
 
-        // Read current notes
-        var notesJson = clip.call("get_all_notes_extended");
-        var notes = parseNotesResponse(notesJson);
+        var notes = this._readClipNotes(clip);
         if (!notes || !notes.notes) {
-            debug("restoreTemperatureState", "No notes to restore");
             delete this.temperatureState[clipId];
             return;
         }
 
-        // Calculate pitch adjustment based on current pitch sequencer state
-        // If pitch is currently on, we need to add the shift to the base pitch
         var pitchAdjustment = this._getCurrentPitchOffset(clipId);
 
-        // Restore each note's pitch from the map
         var changed = false;
-        var restoredCount = 0;
-        var skippedCount = 0;
-
         for (var i = 0; i < notes.notes.length; i++) {
             var note = notes.notes[i];
-            var originalPitch = state.originalPitches[note.note_id];
-
-            if (originalPitch !== undefined) {
-                // Known note - restore to original base pitch + current pitch adjustment
-                note.pitch = originalPitch + pitchAdjustment;
+            var base = state.baseModel[note.note_id];
+            if (base) {
+                note.pitch = base.pitch + pitchAdjustment;
                 changed = true;
-                restoredCount++;
-            } else {
-                // New note from overdub - keep current pitch
-                skippedCount++;
             }
+            // Notes not in the base model are user overdubs that were not yet
+            // re-baselined; leave them untouched.
         }
 
-        // Apply modifications if any changes were made
         if (changed) {
             try {
                 clip.call("apply_note_modifications", notes);
-                debug("restoreTemperatureState", "Restored " + restoredCount + " notes, skipped " + skippedCount + " (overdubs)");
             } catch (error) {
-                handleError("restoreTemperatureState", error, false);
+                handleError("restoreBaseModel", error, false);
             }
         }
 
-        // Clear state
         delete this.temperatureState[clipId];
     };
 
+    // ===== VARIATION =====
+
     /**
-     * Handle temperature loop jump.
-     * Restores to original pitches first, then applies fresh random shuffle.
-     * Each loop shuffles from the original—no cumulative scrambling.
+     * Apply a fresh variation derived from the base model.
+     * Always: load base pitches (+ current pitch shift) -> new swap -> write.
+     * Records `expected` so the notes observer recognises this write.
+     *
+     * @param {string} clipId
+     */
+    proto.applyTemperatureVariation = function(clipId) {
+        if (!this.temperatureActive || this.temperatureValue <= 0) return;
+
+        var clip = this.getCurrentClip();
+        if (!clip || clip.id !== clipId) return;
+
+        var state = this.temperatureState[clipId];
+        if (!state) {
+            debug("applyTemperatureVariation", "No base model for clip " + clipId);
+            return;
+        }
+
+        var notes = this._readClipNotes(clip);
+        if (!notes || !notes.notes) return;
+
+        var pitchAdjustment = this._getCurrentPitchOffset(clipId);
+
+        // 1. Reset every known note to its base pitch (+ current pitch shift).
+        //    This is what makes variation non-cumulative: we always start from
+        //    the base model, never from the previous scramble.
+        for (var i = 0; i < notes.notes.length; i++) {
+            var note = notes.notes[i];
+            var base = state.baseModel[note.note_id];
+            if (base) {
+                note.pitch = base.pitch + pitchAdjustment;
+            }
+        }
+
+        // 2. Generate a new swap pattern from the (now base) pitches.
+        this.temperatureSwapPattern = generateSwapPattern(
+            notes.notes,
+            this.temperatureValue
+        );
+
+        // 3. Apply the swap.
+        applySwapPattern(notes.notes, this.temperatureSwapPattern);
+
+        // 4. Record expected BEFORE writing. apply_note_modifications queues a
+        //    "notes" notification synchronously; recording after the write would
+        //    race that notification and our own write could be misread as a user
+        //    edit. Setting expected first makes the diff correct regardless of
+        //    notification timing.
+        this._recordExpected(notes.notes, clipId);
+
+        // 5. Write.
+        try {
+            clip.call("apply_note_modifications", notes);
+            debug("temperature", "Applied variation from base model (" +
+                this.temperatureSwapPattern.length + " groups)");
+        } catch (error) {
+            handleError("applyTemperatureVariation", error, false);
+        }
+    };
+
+    /**
+     * Loop jump -> apply a fresh variation from the base model.
      */
     proto.onTemperatureLoopJump = function() {
+        if (!this.temperatureActive || this.temperatureValue <= 0) return;
+        var clip = this.getCurrentClip();
+        if (!clip) return;
+        this.applyTemperatureVariation(clip.id);
+    };
+
+    /**
+     * Notes-changed -> distinguish our own write from a user edit.
+     * On a user edit, re-baseline: the current notes become the new base model,
+     * accepting that the prior original is intentionally superseded.
+     */
+    proto.onTemperatureNotesChanged = function() {
         if (!this.temperatureActive || this.temperatureValue <= 0) return;
 
         var clip = this.getCurrentClip();
@@ -246,49 +424,61 @@ function applyTemperatureMethods(proto) {
 
         var clipId = clip.id;
         var state = this.temperatureState[clipId];
+        if (!state) return;
 
-        // Need temperature state to know original pitches
-        if (!state) {
-            debug("onTemperatureLoopJump", "No temperature state for clip " + clipId);
-            return;
-        }
-
-        // 1. Read current notes
-        var notesJson = clip.call("get_all_notes_extended");
-        var notes = parseNotesResponse(notesJson);
+        var notes = this._readClipNotes(clip);
         if (!notes || !notes.notes) return;
 
-        // 2. Calculate pitch adjustment for current pitch sequencer state
-        var pitchAdjustment = this._getCurrentPitchOffset(clipId);
-
-        // 3. Restore all notes to original pitches first
-        for (var i = 0; i < notes.notes.length; i++) {
-            var note = notes.notes[i];
-            var originalPitch = state.originalPitches[note.note_id];
-            if (originalPitch !== undefined) {
-                // Restore to original + current pitch sequencer adjustment
-                note.pitch = originalPitch + pitchAdjustment;
-            }
-            // Overdubbed notes (not in map) keep their current pitch
+        if (!this._isExternalChange(notes.notes, state.expected)) {
+            return; // our own swap write; ignore
         }
 
-        // 4. Generate NEW random swap pattern based on temperature
-        this.temperatureSwapPattern = generateSwapPattern(
-            notes.notes,
-            this.temperatureValue
-        );
+        // User edited the clip while hot. The edited notes currently include
+        // our last swap, so first undo the swap on known notes to recover the
+        // user's intended base pitches, then re-baseline to that.
+        var pitchShift = this._getCurrentPitchOffset(clipId);
 
-        debug("temperature", "Generated " + this.temperatureSwapPattern.length + " swap groups from original");
+        // Re-baseline directly from current notes. New/edited notes define the
+        // new composition; we cannot un-swap notes we don't recognise, and
+        // recognised notes that the user did NOT touch still hold our swap, so
+        // we reverse our last swap on them before snapshotting.
+        this._reverseExpectedSwap(notes.notes, state, pitchShift);
 
-        // 5. Apply swaps to the restored original pitches
-        applySwapPattern(notes.notes, this.temperatureSwapPattern);
+        this.temperatureState[clipId] = {
+            baseModel: this._buildBaseModel(notes.notes, pitchShift),
+            expected: null
+        };
 
-        // 6. Apply to clip
-        try {
-            clip.call("apply_note_modifications", notes);
-            debug("temperature", "Applied temperature transformation from original");
-        } catch (error) {
-            handleError("onTemperatureLoopJump", error, false);
+        debug("temperature", "Re-baselined from user edit (" +
+            notes.notes.length + " notes)");
+
+        // Immediately apply a fresh variation from the new base so playback
+        // stays hot and consistent.
+        this.applyTemperatureVariation(clipId);
+    };
+
+    /**
+     * Reverse our last swap on notes that still match `expected`, restoring
+     * them to their base pitch, so the re-baseline snapshot reflects the user's
+     * composition rather than our scramble. Notes the user touched (pitch !=
+     * expected, or unknown id) are left as-is — that's their new intent.
+     *
+     * @param {Array} notes - current clip notes (mutated in place)
+     * @param {Object} state - temperatureState entry with baseModel + expected
+     * @param {number} pitchShift - current pitch sequencer offset
+     */
+    proto._reverseExpectedSwap = function(notes, state, pitchShift) {
+        if (!state.expected || !state.baseModel) return;
+        for (var i = 0; i < notes.length; i++) {
+            var note = notes[i];
+            var expectedPitch = state.expected[note.note_id];
+            var base = state.baseModel[note.note_id];
+            // Only revert notes that are exactly where our swap left them AND
+            // that we have a base pitch for. A user-edited note (pitch differs
+            // from expected) is preserved as the new intent.
+            if (base && expectedPitch !== undefined && note.pitch === expectedPitch) {
+                note.pitch = base.pitch + pitchShift;
+            }
         }
     };
 }

--- a/permute-temperature.js
+++ b/permute-temperature.js
@@ -262,6 +262,14 @@ function applyTemperatureMethods(proto) {
      * @param {string} clipId
      */
     proto.captureBaseModel = function(clipId) {
+        // Self-enforce the no-overwrite contract. Re-baseline assigns
+        // temperatureState directly; capture must never clobber an existing
+        // base model, even if a future caller forgets to guard.
+        if (this.temperatureState[clipId]) {
+            debug("captureBaseModel", "Base model already exists for " + clipId + ", skipping");
+            return;
+        }
+
         var clip = this.getCurrentClip();
         if (!clip || clip.id !== clipId) {
             debug("captureBaseModel", "Clip unavailable or ID mismatch");
@@ -286,10 +294,13 @@ function applyTemperatureMethods(proto) {
     };
 
     /**
-     * Restore the base model verbatim (all fields), then clear temperature
-     * state. Notes the user added after capture are removed only if they were
-     * never folded in; in practice re-baseline keeps the model current, so the
-     * base model is authoritative and we restore exactly it.
+     * Restore base-model pitches to the clip (pitch only — the swap only ever
+     * changes pitch, so other fields are already at their base values), then
+     * clear temperature state. Notes known in the base model are set to
+     * base.pitch + current pitch-sequencer offset. Overdubbed notes not yet
+     * folded in via re-baseline are left at their current clip pitch (which,
+     * thanks to applyTemperatureVariation never swapping non-base notes, is the
+     * pitch the user recorded — not a scramble).
      *
      * @param {string} clipId
      */
@@ -364,31 +375,39 @@ function applyTemperatureMethods(proto) {
 
         var pitchAdjustment = this._getCurrentPitchOffset(clipId);
 
-        // 1. Reset every known note to its base pitch (+ current pitch shift).
-        //    This is what makes variation non-cumulative: we always start from
-        //    the base model, never from the previous scramble.
+        // 1. Reset every known note to its base pitch (+ current pitch shift),
+        //    and collect only base-model notes as the swap pool. Notes absent
+        //    from the base model are overdubs not yet re-baselined: we must
+        //    NEVER swap them, otherwise returning to 0 before the notes observer
+        //    fires would leave them at a scrambled pitch (restoreBaseModel only
+        //    restores base-model notes). Excluding them keeps their pitch stable
+        //    until a re-baseline folds them in.
+        var baseNotes = [];
         for (var i = 0; i < notes.notes.length; i++) {
             var note = notes.notes[i];
             var base = state.baseModel[note.note_id];
             if (base) {
                 note.pitch = base.pitch + pitchAdjustment;
+                baseNotes.push(note);
             }
         }
 
         // 2. Generate a new swap pattern from the (now base) pitches.
         this.temperatureSwapPattern = generateSwapPattern(
-            notes.notes,
+            baseNotes,
             this.temperatureValue
         );
 
-        // 3. Apply the swap.
-        applySwapPattern(notes.notes, this.temperatureSwapPattern);
+        // 3. Apply the swap to the base-note subset (references into notes.notes,
+        //    so the mutations propagate to the full array we write below).
+        applySwapPattern(baseNotes, this.temperatureSwapPattern);
 
         // 4. Record expected BEFORE writing. apply_note_modifications queues a
         //    "notes" notification synchronously; recording after the write would
         //    race that notification and our own write could be misread as a user
         //    edit. Setting expected first makes the diff correct regardless of
-        //    notification timing.
+        //    notification timing. Record over the full written set so overdub
+        //    pitches are part of `expected` and don't read as external changes.
         this._recordExpected(notes.notes, clipId);
 
         // 5. Write.
@@ -442,6 +461,10 @@ function applyTemperatureMethods(proto) {
         // new composition; we cannot un-swap notes we don't recognise, and
         // recognised notes that the user did NOT touch still hold our swap, so
         // we reverse our last swap on them before snapshotting.
+        // NOTE: _reverseExpectedSwap mutates only the in-memory notes array so
+        // the _buildBaseModel below captures the user's intended composition,
+        // not our scramble. It does NOT write to the clip; the write is done by
+        // applyTemperatureVariation at the end of this function.
         this._reverseExpectedSwap(notes.notes, state, pitchShift);
 
         this.temperatureState[clipId] = {


### PR DESCRIPTION
## Summary
- Returning the temperature control to 0 was losing notes. The id-tracking math was correct, but the state defining "original" was being destroyed/rebuilt at the wrong moments (transport stop deleted state then re-captured the scrambled clip on restart; deferred loop-jumps raced return-to-0; overdubs corrupted the clip).
- Flips the model: the user's composition is the source of truth, held in an in-memory **base model** per clip. The scrambled clip is never read back as truth. `displayed = applySwap(baseModel, temp)`, so return-to-0 rewrites the base verbatim and is lossless by construction rather than by maintaining reversibility.
- User edits/overdubs while temperature is hot are detected by a **content diff** (compare clip to the exact pitches we wrote), making the loop-jump race timing-independent. A user edit re-baselines to the new notes (an edit is treated as new intent; prior original is intentionally superseded — confirmed design decision).

## Key changes
- `permute-temperature.js` — base model capture/restore/variation, `notes` observer + content diff, re-baseline. `expected` recorded **before** the write to avoid racing the notification.
- `permute-device.js` — transport start re-derives from base (no re-capture); transport stop writes clean original to clip but keeps base model in memory; `onClipChanged` / `_setCachedClip` updated; new `temperatureState` shape.
- `docs/adr/015-temperature-base-model.md` (new), CLAUDE.md + ADR 106 cross-link.

## Verification
Ran the real `permute-temperature.js` + `permute-shuffle.js` against a mock clip (Node harness):
- 200 loop jumps on one clip → return-to-0 lossless
- transport stop/start cycles → return-to-0 lossless
- overdub while hot → originals restored, overdub preserved
- user repitches an existing note while hot → that note becomes new base, others restore
- pitch sequencer on during temperature → return-to-0 keeps the octave shift

The harness also caught a real timing race (recording `expected` after the write) — fixed.

## Test plan
- [ ] Load `Permute.amxd` (delete + re-add, since module files changed and autowatch only watches `permute-device.js`)
- [ ] Raise temp, let the clip loop several times, drag temp back to 0 → clip is pristine
- [ ] Repeat with a transport stop/start in between
- [ ] Overdub a note while temp is hot, then return to 0 → overdub kept, originals restored
- [ ] Temp + pitch sequencer both on → return to 0 keeps the octave shift

🤖 Generated with [Claude Code](https://claude.com/claude-code)